### PR TITLE
add iothreads feature

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -33,7 +33,7 @@ objects:
     template:
       spec:
         domain:
-{%- if item.iothreads == true %} {{''}}
+{%- if item.iothreads %}
           ioThreadsPolicy: shared
 {% endif %}
 

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -32,7 +32,7 @@ objects:
     template:
       spec:
         domain:
-{%- if item.iothreads %} {{''}}
+{% if item.iothreads %}
           ioThreadsPolicy: shared
 {% endif %}
 

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -32,7 +32,7 @@ objects:
     template:
       spec:
         domain:
-{%- if item.iothreads %}
+{%- if item.iothreads %} {{''}}
           ioThreadsPolicy: shared
 {% endif %}
 

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -12,7 +12,6 @@
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
-      /objects[0].spec.template.spec.ioThreadsPolicy
 
   labels:
 {% for osl in oslabels %}

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -12,6 +12,7 @@
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
+      /objects[0].spec.template.spec.ioThreadsPolicy
 
   labels:
 {% for osl in oslabels %}
@@ -32,6 +33,11 @@ objects:
     template:
       spec:
         domain:
+{%- if item.iothreads == true %} {{''}}
+          ioThreadsPolicy: shared
+{%- elif item.iothreads == false or item.iothreads is not defined %}
+{% endif %}
+
           cpu:
             cores: {{ item.cores }}
 {% if cpumodel |default("") %}

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -35,7 +35,6 @@ objects:
         domain:
 {%- if item.iothreads == true %} {{''}}
           ioThreadsPolicy: shared
-{%- elif item.iothreads == false or item.iothreads is not defined %}
 {% endif %}
 
           cpu:


### PR DESCRIPTION
Add ioThreads feature in the Linux template generator.
By default uses **shared** ioThread policy.  But adds it as editable parameter. 
Current templates uses 2 cores maximum. It's a reason why I choose **shared** ioThread policy.

If user edit .spec.template.spec.domain.cpu.cores, then it can have a wish to edit ioThread policy to. 
So, user has this option.

In this time CNV supports only two policies - _shared_ and _auto_.