### PR TITLE
Generated name must be all lowercase

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -61,7 +61,7 @@ objects:
 
 parameters:
 - description: VM name
-  from: '{{ os }}-[A-Za-z0-9]{16}'
+  from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
 - name: PVCNAME


### PR DESCRIPTION
This fixes an issue Xenia found where the generated name was rejected by minishift:

```
/opt/minishift/oc process --local -f dist/templates/fedora-generic-tiny.yaml PVCNAME=mydisk | kubectl apply -f -
The VirtualMachine "fedora-Nlxy4wkUcsIjcwR6" is invalid: metadata.name: Invalid value: "fedora-Nlxy4wkUcsIjcwR6": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```