### PR TITLE
add other templates to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,19 @@ jobs:
     script: bash -x test.sh
 
   - name: Functional test of the Fedora template
-    env: TARGET=functional-tests TEST_FUNCTIONAL=fedora-generic-small
+    env: TARGET=functional-tests TEST_FUNCTIONAL="fedora-generic-tiny fedora-generic-small fedora-generic-medium fedora-generic-large"
     script: bash -x test.sh
 
   - name: Functional test of the Ubuntu template
-    env: TARGET=functional-tests TEST_FUNCTIONAL=ubuntu-generic-small
+    env: TARGET=functional-tests TEST_FUNCTIONAL="ubuntu-generic-tiny ubuntu-generic-small ubuntu-generic-medium ubuntu-generic-large"
     script: bash -x test.sh
 
   - name: Functional test of the RHEL template
-    env: TARGET=functional-tests TEST_FUNCTIONAL=rhel7-generic-small
+    env: TARGET=functional-tests TEST_FUNCTIONAL="rhel7-generic-tiny rhel7-generic-small rhel7-generic-medium rhel7-generic-large"
     script: bash -x test.sh
 
   - name: Functional test of the CentOS template
-    env: TARGET=functional-tests TEST_FUNCTIONAL=centos7-generic-small
+    env: TARGET=functional-tests TEST_FUNCTIONAL="centos7-generic-tiny centos7-generic-small centos7-generic-medium centos7-generic-large"
     script: bash -x test.sh
 
   - stage: Build and Deploy

--- a/automation/x-limit-ram-size.sh
+++ b/automation/x-limit-ram-size.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Due to travis restrictions, travis job instances have only 7.5 GB of memory.
+# This script updates ram size in all large templates 
+for filename in dist/templates/*-large.yaml; do
+    sed -i -e 's/8G/6G/g' $filename
+done


### PR DESCRIPTION
add other sizes of templates to tests. Due to travis restrictions, large templates have to be updated to use only 6GB of RAM.