### PR TITLE
fix bug when more tests use same image

### DIFF
--- a/makefile
+++ b/makefile
@@ -91,6 +91,8 @@ generate: generate-templates.yaml $(METASOURCES)
 	virtctl console --timeout=5 $* | tee /dev/stderr | egrep -m 1 "Welcome|systemd"
 	oc process --local -f "dist/templates/$*.yaml" NAME=$* PVCNAME=$* | \
 	  kubectl delete -f -
+	# Wait for successful vmi deletion
+	while kubectl get vmi $* 2> >(grep "not found") ; do sleep 15; done
 
 pvs: $(TESTABLE_GUESTS:%=%.pv)
 raws: $(TESTABLE_GUESTS:%=%.raw)


### PR DESCRIPTION
when more tests run, sometimes it takes lot of time to delete previous vmi. And there is an issue, that kubernetes deletes image which new vm needs when it deletes old vm.