### PR TITLE
fix failing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   - "/^v[0-9]/"
 env:
   global:
-  - KUBEVIRT_VER=v0.8.0
+  - KUBEVIRT_VER=v0.10.0
   - CPLATFORM=minikube CDIST=kubernetes CVER=1.11.2
 jobs:
   include:

--- a/makefile
+++ b/makefile
@@ -91,6 +91,8 @@ generate: generate-templates.yaml $(METASOURCES)
 	virtctl console --timeout=5 $* | tee /dev/stderr | egrep -m 1 "Welcome|systemd"
 	oc process --local -f "dist/templates/$*.yaml" NAME=$* PVCNAME=$* | \
 	  kubectl delete -f -
+	# Wait for successful vmi deletion
+	while kubectl get vmi $* 2> >(grep "not found") ; do sleep 15; done
 
 pvs: $(TESTABLE_GUESTS:%=%.pv)
 raws: $(TESTABLE_GUESTS:%=%.raw)


### PR DESCRIPTION
Failing of travis builds is probably caused by old version of kubevirt. This PR changes version to 0.10.0.
Added check which waits until vm is deleted.