### PR TITLE
turn off ansible gather_facts

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -1,6 +1,7 @@
 ---
 - connection: local
   hosts: 127.0.0.1
+  gather_facts: no
   tasks:
   - name: Prepare dist directory
     file:


### PR DESCRIPTION
This patchs turns off ansible gather_facts, because it fails stdci test