### PR TITLE
add desktop type for rhel, centos, windows os

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,16 @@ jobs:
     env: TARGET=functional-tests TEST_FUNCTIONAL="rhel7-generic-tiny rhel7-generic-small rhel7-generic-medium rhel7-generic-large"
     script: bash -x test.sh
 
+  - name: Functional test of the desktop RHEL template
+    env: TARGET=functional-tests TEST_FUNCTIONAL="rhel7-desktop-tiny rhel7-desktop-small rhel7-desktop-medium rhel7-desktop-large"
+    script: bash -x test.sh
+
   - name: Functional test of the CentOS template
     env: TARGET=functional-tests TEST_FUNCTIONAL="centos7-generic-tiny centos7-generic-small centos7-generic-medium centos7-generic-large"
+    script: bash -x test.sh
+
+  - name: Functional test of the desktop CentOS template
+    env: TARGET=functional-tests TEST_FUNCTIONAL="centos7-desktop-tiny centos7-desktop-small centos7-desktop-medium centos7-desktop-large"
     script: bash -x test.sh
 
   - stage: Build and Deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   - /^v[0-9]/
 env:
   global:
-  - KUBEVIRT_VER=v0.13.0
+  - KUBEVIRT_VER=v0.15.0-alpha.0
   - CPLATFORM=minikube CVER=1.11.2
 jobs:
   include:

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -238,7 +238,7 @@ _oc exec -it winrmcli -- yum install -y iproute iputils
 
 kubeconfig="cluster/$KUBEVIRT_PROVIDER/.kubeconfig"
 sizes=("medium" "large")
-workloads=("generic", "desktop")
+workloads=("generic" "desktop")
 for size in ${sizes[@]}; do
   for workload in ${workloads[@]}; do
     windowsTemplatePath="../../dist/templates/win2k12r2-$workload-$size.yaml"

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -58,7 +58,6 @@ safe_download() (
     fi
 )
 
-
 # Create images directory
 if [[ ! -d $WINDOWS_NFS_DIR ]]; then
   mkdir -p $WINDOWS_NFS_DIR
@@ -95,7 +94,7 @@ else
 fi
 
 export KUBEVIRT_PROVIDER="os-3.11.0"
-export VERSION="v0.13.0"
+export VERSION="v0.15.0-alpha.0"
 
 curl -Lo virtctl \
     https://github.com/kubevirt/kubevirt/releases/download/$VERSION/virtctl-$VERSION-linux-amd64
@@ -119,13 +118,12 @@ set -e
 echo "Nodes are ready:"
 _oc get nodes
 
-_oc describe nodes
-
 _oc adm policy add-scc-to-user privileged system:serviceaccount:kubevirt:kubevirt-privileged
 _oc adm policy add-scc-to-user privileged system:serviceaccount:kubevirt:kubevirt-controller
 _oc adm policy add-scc-to-user privileged system:serviceaccount:kubevirt:kubevirt-apiserver
+_oc adm policy add-scc-to-user privileged system:serviceaccount:kubevirt:kubevirt-handler
 
-_oc create \
+_oc apply \
     -f https://github.com/kubevirt/kubevirt/releases/download/$VERSION/kubevirt.yaml
 
 export NAMESPACE="${NAMESPACE:-kubevirt}"

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -123,9 +123,9 @@
       src: win2k12r2.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/win2k12r2-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
-    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False}
+    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False, tablet: False}
+    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False, tablet: True}
     vars:
       osinfoname: win2k12r2

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -14,12 +14,16 @@
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
     - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False}
+    - {flavor: tiny, workload: desktop, memsize: "1G", cpus: 1, iothreads: False}
     - {flavor: tiny, workload: highperformance, memsize: "1G", cpus: 1, iothreads: True}
     - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False}
+    - {flavor: small, workload: desktop, memsize: "2G", cpus: 1, iothreads: False}
     - {flavor: small, workload: highperformance, memsize: "2G", cpus: 1, iothreads: True}
     - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
+    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False}
     - {flavor: medium, workload: highperformance, memsize: "4G", cpus: 1, iothreads: True}
     - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
+    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False}
     - {flavor: large, workload: highperformance, memsize: "8G", cpus: 2, iothreads: True}
     vars:
       os: rhel7
@@ -41,9 +45,13 @@
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
     - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False}
+    - {flavor: tiny, workload: desktop, memsize: "1G", cpus: 1, iothreads: False}
     - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False}
+    - {flavor: small, workload: desktop, memsize: "2G", cpus: 1, iothreads: False}
     - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
+    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False}
     - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
+    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False}
     vars:
       os: centos7
       icon: centos
@@ -116,8 +124,8 @@
       dest: "{{ playbook_dir }}/dist/templates/win2k12r2-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
     - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
+    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False}
     - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
+    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False}
     vars:
       osinfoname: win2k12r2
-
-

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -13,18 +13,18 @@
       src: rhel7.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False}
-    - {flavor: tiny, workload: desktop, memsize: "1G", cpus: 1, iothreads: False}
-    - {flavor: tiny, workload: highperformance, memsize: "1G", cpus: 1, iothreads: True}
-    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False}
-    - {flavor: small, workload: desktop, memsize: "2G", cpus: 1, iothreads: False}
-    - {flavor: small, workload: highperformance, memsize: "2G", cpus: 1, iothreads: True}
-    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: medium, workload: highperformance, memsize: "4G", cpus: 1, iothreads: True}
-    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
-    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False}
-    - {flavor: large, workload: highperformance, memsize: "8G", cpus: 2, iothreads: True}
+    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: tiny, workload: desktop, memsize: "1G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: tiny, workload: highperformance, memsize: "1G", cpus: 1, iothreads: True, tablet: False}
+    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: small, workload: desktop, memsize: "2G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: small, workload: highperformance, memsize: "2G", cpus: 1, iothreads: True, tablet: False}
+    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: medium, workload: highperformance, memsize: "4G", cpus: 1, iothreads: True, tablet: False}
+    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False, tablet: False}
+    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False, tablet: True}
+    - {flavor: large, workload: highperformance, memsize: "8G", cpus: 2, iothreads: True, tablet: False}
     vars:
       os: rhel7
       icon: rhel
@@ -44,14 +44,14 @@
       src: centos7.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False}
-    - {flavor: tiny, workload: desktop, memsize: "1G", cpus: 1, iothreads: False}
-    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False}
-    - {flavor: small, workload: desktop, memsize: "2G", cpus: 1, iothreads: False}
-    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
-    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False}
+    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: tiny, workload: desktop, memsize: "1G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: small, workload: desktop, memsize: "2G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: medium, workload: desktop, memsize: "4G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False, tablet: False}
+    - {flavor: large, workload: desktop, memsize: "8G", cpus: 2, iothreads: False, tablet: True}
     vars:
       os: centos7
       icon: centos
@@ -65,14 +65,14 @@
       src: fedora.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False}
-    - {flavor: tiny, workload: highperformance, memsize: "1G", cpus: 1, iothreads: True}
-    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False}
-    - {flavor: small, workload: highperformance, memsize: "2G", cpus: 1, iothreads: True}
-    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: medium, workload: highperformance, memsize: "4G", cpus: 1, iothreads: True}
-    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
-    - {flavor: large, workload: highperformance, memsize: "8G", cpus: 2, iothreads: True}
+    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: tiny, workload: highperformance, memsize: "1G", cpus: 1, iothreads: True, tablet: False}
+    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: small, workload: highperformance, memsize: "2G", cpus: 1, iothreads: True, tablet: False}
+    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: medium, workload: highperformance, memsize: "4G", cpus: 1, iothreads: True, tablet: False}
+    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False, tablet: True}
+    - {flavor: large, workload: highperformance, memsize: "8G", cpus: 2, iothreads: True, tablet: False}
     vars:
       os: fedora
       icon: fedora
@@ -88,10 +88,10 @@
       src: opensuse.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False}
-    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False}
-    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
+    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False, tablet: False}
     vars:
       os: opensuse
       icon: opensuse
@@ -105,10 +105,10 @@
       src: ubuntu.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False}
-    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False}
-    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False}
-    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False}
+    - {flavor: tiny, workload: generic, memsize: "1G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: small, workload: generic, memsize: "2G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: medium, workload: generic, memsize: "4G", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: large, workload: generic, memsize: "8G", cpus: 2, iothreads: False, tablet: True}
     vars:
       cpumodel: Conroe
       os: ubuntu

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -56,6 +56,12 @@ objects:
               memory: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.tablet %}
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+{% endif %}
             disks:
             - disk:
                 bus: virtio

--- a/templates/win2k12r2.tpl.yaml
+++ b/templates/win2k12r2.tpl.yaml
@@ -87,6 +87,12 @@ objects:
             - bridge: {}
               model: e1000e
               name: default
+{% if item.tablet %}
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+{% endif %}
         terminationGracePeriodSeconds: 0
         volumes:
         - name: rootdisk


### PR DESCRIPTION
This PR adds desktop type for rhel, centos, windows os.
Desktop type templates (rhel, centos) and fedora, ubuntu will contains table devices