### PR TITLE
Add required memory validation rules (and update the osinfodb)

### DIFF
--- a/automation/check-patch.rhel8.packages
+++ b/automation/check-patch.rhel8.packages
@@ -2,6 +2,8 @@ git
 docker
 jq
 ansible
+intltool
+osinfo-db-tools
 libosinfo
 expect
 python-gobject

--- a/automation/check-patch.windows2016.packages
+++ b/automation/check-patch.windows2016.packages
@@ -2,5 +2,7 @@ git
 docker
 jq
 ansible
+intltool
+osinfo-db-tools
 libosinfo
 python-gobject

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -131,6 +131,7 @@ _oc() { cluster/kubectl.sh "$@"; }
 
 git submodule update --init
 
+make -C osinfo-db/ OSINFO_DB_EXPORT=echo
 ansible-playbook generate-templates.yaml
 
 cp automation/connect_to_rhel_console.exp automation/kubevirt/connect_to_rhel_console.exp 

--- a/lookup_plugins/osinfo.py
+++ b/lookup_plugins/osinfo.py
@@ -61,7 +61,8 @@ class OsInfoGObjectProxy(object):
             return False
 
     def _resolve(self, val, path):
-        if (type(val) == int or type(val) == float or type(val) == str or
+        if (type(val) == int or type(val) == long or
+                type(val) == float or type(val) == str or
                 type(val) == unicode or type(val) == bool):
             return val
         else:
@@ -104,6 +105,7 @@ class LookupModule(LookupBase):
                 os = OsInfoGObjectProxy(oses.get_nth(0), root_path = "[" + term + "]")
                 ret.append(os)
             else:
+                print("OS {} not found".format(term))
                 ret.append({"name": term})
 
         return ret

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -19,6 +19,17 @@
     name.os.template.kubevirt.io/{{ osl }}: {{ lookup('osinfo', osl).name }}
 {% endfor %}
 
+    validations: |
+      [
+        {
+          "name": "minimal-required-memory",
+          "path": "jsonpath::.spec.domain.resources.requests.memory",
+          "rule": "integer",
+          "message": "This VM requires more memory.",
+          "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
+        },
+      ]
+
   labels:
 {% for osl in oslabels %}
     os.template.kubevirt.io/{{ osl }}: "true"

--- a/templates/win2k12r2.tpl.yaml
+++ b/templates/win2k12r2.tpl.yaml
@@ -31,6 +31,17 @@ metadata:
     name.os.template.kubevirt.io/win2k8: {{ lookup('osinfo', 'win2k8').name }}
     name.os.template.kubevirt.io/win10: {{ lookup('osinfo', 'win10').name }}
 
+    validations: |
+      [
+        {
+          "name": "minimal-required-memory",
+          "path": "jsonpath::.spec.domain.resources.requests.memory",
+          "rule": "integer",
+          "message": "This VM requires more memory.",
+          "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
+        }
+      ]
+
   labels:
     os.template.kubevirt.io/win2k12r2: "true"
     os.template.kubevirt.io/win2k8r2: "true"


### PR DESCRIPTION
This patch is an example of how to add validations that are based on libosinfo data. So far only the minimal memory requirements are checked.
Updated version of osinfo-db