### PR TITLE
windows: templates: use synic flags

### DIFF
--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -134,6 +134,7 @@ for size in ${sizes[@]}; do
         exit 1
       fi
       sleep 10;
+      _oc exec -it winrmcli -- ./usr/bin/winrm-cli -hostname $ipAddressVMI -port 5985 -username "Administrator" -password "Heslo123" "ipconfig /all"
     done
 
     ./virtctl --kubeconfig=$kubeconfig stop $template_name-$workload-$size 

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -128,7 +128,7 @@ for size in ${sizes[@]}; do
     set +e
     current_time=0
     # run ipconfig /all command on windows vm
-    while [[ $(_oc exec -it winrmcli -- ./usr/bin/winrm-cli -hostname $ipAddressVMI -port 5985 -username "Administrator" -password "Heslo123" "ipconfig /all") != *"$ipAddressVMI"* ]] ; do 
+    while [[ $(_oc exec -it winrmcli -- ./usr/bin/winrm-cli -hostname $ipAddressVMI -port 5985 -username "Administrator" -password "Heslo123" "ipconfig /all" | grep "IPv4 Address") != *"$ipAddressVMI"* ]] ; do
       current_time=$((current_time + 10))
       if [[ $current_time -gt $timeout ]]; then
         exit 1

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -117,6 +117,11 @@ for size in ${sizes[@]}; do
     _oc describe vm $template_name-$workload-$size
     _oc describe vmi $template_name-$workload-$size
 
+    _oc get pods --all-namespaces -l "kubevirt.io=virt-launcher" -o=go-template --template='{{ range .items }}-n {{.metadata.namespace}} {{.metadata.name}}{{ "\n" }}{{ end }}' | while read vmPodId; do
+       _oc exec -ti $vmPodId -- virsh -r dumpxml 1
+       _oc logs $vmPodId
+    done
+
     # get ip address of vm
     ipAddressVMI=$(_oc get vmi $template_name-$workload-$size -o json| jq -r '.status.interfaces[0].ipAddress')
 

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -2,7 +2,7 @@
 sub-stages:
   - windows2012
   - windows2016
-  - windows2019
+#  - windows2019
   - windows10
   - rhel6
   - rhel7

--- a/templates/win2k12r2.tpl.yaml
+++ b/templates/win2k12r2.tpl.yaml
@@ -92,8 +92,6 @@ objects:
               vpindex: {}
               spinlocks:
                 spinlocks: 8191
-              synic: {}
-              synictimer: {}
           devices:
             disks:
             - disk:

--- a/templates/win2k12r2.tpl.yaml
+++ b/templates/win2k12r2.tpl.yaml
@@ -89,8 +89,11 @@ objects:
             hyperv:
               relaxed: {}
               vapic: {}
+              vpindex: {}
               spinlocks:
                 spinlocks: 8191
+              synic: {}
+              synictimer: {}
           devices:
             disks:
             - disk:


### PR DESCRIPTION
Kubevirt gained support for pretty much all the hyper-v related flags
exposed in libvirt 5.1.
In this patch we update the common templates to use some of them.
We start with the following:

- synic: needed to enable synictimer
- synictimer: reportedly improves performance significantly
     on windows >= 10
- vpindex: needed for few optimization on overcommitted environments
     (ipi, tlbflush). It is expected NOT to harm performances if enabled
     alone, we enable to prepare for the aforementioned optimizations.

Please note that we DO NOT assume or require the HyperV strict
checking[1].
We leave that to the cluster admin or to some other opinionated setups.

+++

[1]: https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/guest-operating-system-information.html#hyperv-optimizations

Signed-off-by: Francesco Romani <fromani@redhat.com>