### PR TITLE
change default interface to masquerade instead of bridge

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -87,7 +87,7 @@ objects:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk
             interfaces:
-            - bridge: {}
+            - masquerade: {}
               name: default
         terminationGracePeriodSeconds: 0
         networks:

--- a/templates/win2k12r2.tpl.yaml
+++ b/templates/win2k12r2.tpl.yaml
@@ -112,7 +112,7 @@ objects:
                 bus: sata
               name: rootdisk
             interfaces:
-            - bridge: {}
+            - masquerade: {}
               model: e1000e
               name: default
 {% if item.tablet %}


### PR DESCRIPTION
In this PR we changed the default binding method
from _bridge_ to _masquerade_ in the template VMs.

Because live migartion is blocked when binding with _bridge_  on pod network (reasons for that are detailed here : https://github.com/kubevirt/kubevirt/issues/1633),
and because further issues might popup due to the IP delegation   from the hosting pod to the VM 
(more detailes here :  https://github.com/kubevirt/kubevirt/pull/2493),
we would like our template VMs to bind with the more preferable _masquerade_ binding method.

