### PR TITLE
Bump version if osinfodb and fix Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ addons:
     - jq
     - ansible
     - python-gobject
+      python-six
     - libosinfo-1.0
     - gir1.2-libosinfo-1.0
     - intltool

--- a/automation/check-patch.rhel8.packages
+++ b/automation/check-patch.rhel8.packages
@@ -7,3 +7,4 @@ osinfo-db-tools
 libosinfo
 expect
 python-gobject
+python-six

--- a/automation/check-patch.windows2016.packages
+++ b/automation/check-patch.windows2016.packages
@@ -6,3 +6,4 @@ intltool
 osinfo-db-tools
 libosinfo
 python-gobject
+python-six

--- a/lookup_plugins/osinfo.py
+++ b/lookup_plugins/osinfo.py
@@ -10,6 +10,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import six
 import subprocess
 
 from ansible.errors import AnsibleError
@@ -45,9 +46,9 @@ class OsInfoGObjectProxy(object):
         if hasattr(self._obj, "get_" + str(key)):
             return True
         elif hasattr(self._obj, "get_length") and hasattr(self._obj, "get_nth"):
-            if type(key) == int:
+            if isinstance(key, six.integer_types):
                 return self._obj.get_length() > int(key)
-            elif type(key) == str or type(key) == unicode:
+            elif isinstance(key, six.string_types):
                 conditions = [v.split("=", 1) for v in key.split(",")]
                 conditions = {v[0] : v[1] for v in conditions}
                 matches = 0
@@ -61,9 +62,9 @@ class OsInfoGObjectProxy(object):
             return False
 
     def _resolve(self, val, path):
-        if (type(val) == int or type(val) == long or
-                type(val) == float or type(val) == str or
-                type(val) == unicode or type(val) == bool):
+        if (isinstance(val, six.integer_types) or
+                type(val) == float or type(val) == bool or
+                isinstance(val, six.string_types)):
             return val
         else:
             return self.__class__(val, root_path = path)


### PR DESCRIPTION
This bumps the osinfo database version. And since I had issues refreshing the templates, it fixes Python 3 support as well.

Signed-off-by: Martin Sivak <msivak@redhat.com>