### PR TITLE
Use networkInterfaceMultiqueue: true

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -73,6 +73,7 @@ objects:
               memory: {{ item.memsize }}
           devices:
             rng: {}
+            networkInterfaceMultiqueue: true
 {% if item.tablet %}
             inputs:
               - type: tablet


### PR DESCRIPTION
this PR changes the template VM to be with
networkInterfaceMultiqueue, in order
to receive better network performances. 
benefits and reasoning behind networkInterfaceMultiqueue 
can be found here: 
https://www.linux-kvm.org/page/Multiqueue#Multiqueue_virtio-net

this PR requires kubevirt version 0.22.0  due to a bug fix included in this version
(https://github.com/kubevirt/kubevirt/pull/2783)