### PR TITLE
Add Fedora 29, Fedora 30 and RHEL 7.7 to the list of guest OSes

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -62,6 +62,7 @@
        - rhel7.4
        - rhel7.5
        - rhel7.6
+       - rhel7.7
       osinfoname: "{{ oslabels[0] }}"
 
   - name: Generate RHEL 6 templates
@@ -187,6 +188,8 @@
        - fedora26
        - fedora27
        - fedora28
+       - fedora29
+       - fedora30
       osinfoname: "{{ oslabels[0] }}"
 
   - name: Generate OpenSUSE templates


### PR DESCRIPTION
Just a refresh to reflect the list of currently supported guest operating systems.