### PR TITLE
Remove unnecessary commands from connect_to_rhel_console.exp file

### DIFF
--- a/automation/connect_to_rhel_console.exp
+++ b/automation/connect_to_rhel_console.exp
@@ -1,8 +1,9 @@
 #!/usr/bin/expect -f
 
+set timeout 300
+
 set kubeconfig [lindex $argv 0]
 set vm_name [lindex $argv 1]
+
 spawn ./virtctl --kubeconfig=$kubeconfig console $vm_name
-expect "Successfully connected to*\r"
-send -- "\r"
-expect "*login*\r"
+expect default { exit 1 } "*Welcome*\r"

--- a/automation/test-rhel.sh
+++ b/automation/test-rhel.sh
@@ -116,18 +116,10 @@ run_vm(){
     _oc describe vmi $vm_name
 
     set +e
-    current_time=0
-    while [  $(./connect_to_rhel_console.exp $kubeconfig $vm_name | grep login | wc -l) -lt 1 ] ; do 
-      echo "waiting for vm to be ready"
-
-      current_time=$((current_time + sample))
-      if [ $current_time -gt $timeout ]; then
-        echo "It should shown login prompt"
-        error=true
-        break
-      fi
-      sleep $sample;
-    done
+    ./connect_to_rhel_console.exp $kubeconfig $vm_name
+    if [ $? -ne 0 ] ; then 
+      error=true
+    fi
     set -e
   
     delete_vm $vm_name $template_path


### PR DESCRIPTION
remove unnecessary commands from connect_to_rhel_console.exp file

Signed-off-by: Karel Šimon <ksimon@redhat.com>