### PR TITLE
Add kubevirt domain label to Windows VMs to fix virtctl expose

### DIFF
--- a/templates/win2k12r2.tpl.yaml
+++ b/templates/win2k12r2.tpl.yaml
@@ -81,6 +81,10 @@ objects:
   spec:
     running: false
     template:
+      metadata:
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: {{ item.flavor }}
       spec:
         domain:
           clock:


### PR DESCRIPTION
This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1769692 I hope.