### PR TITLE
[TEST] Use networkInterfaceMultiqueue: true

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -73,6 +73,7 @@ objects:
               memory: {{ item.memsize }}
           devices:
             rng: {}
+            networkInterfaceMultiqueue: true
 {% if item.tablet %}
             inputs:
               - type: tablet


### PR DESCRIPTION
This PR changes the template VM to be with networkInterfaceMultiqueue, in order
to receive better network performances.
benefits and reasoning behind networkInterfaceMultiqueue
can be found here:
https://www.linux-kvm.org/page/Multiqueue#Multiqueue_virtio-net

Signed-off-by: Karel Šimon <ksimon@redhat.com>