### PR TITLE
Remove template release tag from template name

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -8,6 +8,10 @@ Also, there might be multiple different OSes, flavors, sizes mentioned by any si
 
 Please note that the kubevirt.io suffix used in labels and annotations is temporary and is likely to change.
 
+## Template edits
+
+When an incompatible change is needed, a copy of a template should be created, given new name and edited as needed. The original must stay backwards compatible forever!
+
 ## User Experience
 
 The flow should be the same as usual with regards to openshift templates. The user either takes a local template and generates a VM object.

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -37,6 +37,7 @@
     workload.template.kubevirt.io/{{ item.workload }}: "true"
     flavor.template.kubevirt.io/{{ item.flavor }}: "true"
     template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
 
 objects:
 - apiVersion: kubevirt.io/v1alpha3

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-{{ lookup('env', 'VERSION') | default('devel', true) }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
     openshift.io/display-name: "CentOS 6.0+ VM"
     description: >-

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-{{ lookup('env', 'VERSION') | default('devel', true) }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
     openshift.io/display-name: "CentOS 7.0+ VM"
     description: >-

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-{{ lookup('env', 'VERSION') | default('devel', true) }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
     openshift.io/display-name: "Fedora 23+ VM"
     description: >-

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-{{ lookup('env', 'VERSION') | default('devel', true) }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
     openshift.io/display-name: "OpenSUSE Leap 15.0 VM"
     description: >-

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-{{ lookup('env', 'VERSION') | default('devel', true) }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
     openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
     description: >-

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-{{ lookup('env', 'VERSION') | default('devel', true) }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
     openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
     description: >-

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-{{ lookup('env', 'VERSION') | default('devel', true) }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
     openshift.io/display-name: "Ubuntu 18.04 (Xenial Xerus) VM"
     description: >-

--- a/templates/win2k12r2.tpl.yaml
+++ b/templates/win2k12r2.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: win2k12r2-{{ item.workload }}-{{ item.flavor }}-{{ lookup('env', 'VERSION') | default('devel', true) }}
+  name: win2k12r2-{{ item.workload }}-{{ item.flavor }}
   annotations:
     openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
     description: >-
@@ -67,6 +67,7 @@ metadata:
     workload.template.kubevirt.io/{{ item.workload }}: "true"
     flavor.template.kubevirt.io/{{ item.flavor }}: "true"
     template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
 
 objects:
 - apiVersion: kubevirt.io/v1alpha3


### PR DESCRIPTION
The release tag is kept it the labels for template itself
and in the VM object the template describes. There is
no change there.

Adding the version tag to the template name was a mistake
that will break upgrades. The name should never change.

When an incompatible change is needed, a copy of a template
should be created, given new name and edited as needed.
The original must stay backwards compatible forever!