### PR TITLE
Add fixed version suffix -v0.7.0 to all templates

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
   annotations:
     openshift.io/display-name: "CentOS 6.0+ VM"
     description: >-

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
   annotations:
     openshift.io/display-name: "CentOS 7.0+ VM"
     description: >-

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
   annotations:
     openshift.io/display-name: "Fedora 23+ VM"
     description: >-

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
   annotations:
     openshift.io/display-name: "OpenSUSE Leap 15.0 VM"
     description: >-

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
   annotations:
     openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
     description: >-

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
   annotations:
     openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
     description: >-

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
   annotations:
     openshift.io/display-name: "Ubuntu 18.04 (Xenial Xerus) VM"
     description: >-

--- a/templates/win2k12r2.tpl.yaml
+++ b/templates/win2k12r2.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: win2k12r2-{{ item.workload }}-{{ item.flavor }}
+  name: win2k12r2-{{ item.workload }}-{{ item.flavor }}-v0.7.0
   annotations:
     openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
     description: >-


### PR DESCRIPTION
This is a slight update to the recent patch that removed release
specific suffixes from template names. That fix forgot to take
into account the existing deployments that were done using SSP
operator and HCO.

The last version released via those channels was -v0.7.0 and
so to make upgrades from that release possible, I am readding
the suffix statically.

This can be interpreted as a version in which the template was
first officially released.

v0.7.0 is also the first version that appeared in a product
that supports upgrades. All versions prior that were always
static and had no upgrade guarantees.

Signed-off-by: Martin Sivak <msivak@redhat.com>