### PR TITLE
remove unnecessary trailing comma from validation

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -27,7 +27,7 @@
           "rule": "integer",
           "message": "This VM requires more memory.",
           "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
-        },
+        }
       ]
 
   labels:


### PR DESCRIPTION
Linux templates have unnecessary trailing comma in validation
which causes error. This PR removes it.
//cc @fromanirh, @petrkotas 
Signed-off-by: Karel Šimon <ksimon@redhat.com>