### PR TITLE
fix image downloading in prow tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -21,10 +21,11 @@ set -ex
 
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
 
-export RHEL_NFS_DIR=${RHEL_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/rhel}
-export RHEL_LOCK_PATH=${RHEL_LOCK_PATH:-/var/lib/stdci/shared/download_rhel_image.lock}
-export WINDOWS_NFS_DIR=${WINDOWS_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/windows2016}
-export WINDOWS_LOCK_PATH=${WINDOWS_LOCK_PATH:-/var/lib/stdci/shared/download_windows_image.lock}
+export RHEL_NFS_DIR=${RHEL_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/$TARGET}
+export lock_name="download_${TARGET}_image.lock"
+export RHEL_LOCK_PATH=${RHEL_LOCK_PATH:-/var/lib/stdci/shared/$lock_name}
+export WINDOWS_NFS_DIR=${WINDOWS_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/$TARGET}
+export WINDOWS_LOCK_PATH=${WINDOWS_LOCK_PATH:-/var/lib/stdci/shared/$lock_name}
 export KUBEVIRT_MEMORY_SIZE=16384M
 export KUBEVIRT_PROVIDER="os-3.11.0"
 


### PR DESCRIPTION
This patch should fix the way, how images are downloaded and stored
in prow jobs. Previously, all images were stored in the same folder
under same name. It caused issues. This patch stores each image to its own folder. With this approach each job will have its own folder with image and
it prevents replacing image across jobs.

Signed-off-by: Karel Šimon <ksimon@redhat.com>