### PR TITLE
increased PV size and timeout for windows test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,5 +92,3 @@ before_script:
 - bash -x ci/prepare-host virtctl $(bash -x ci/ci/extra/cat-kubevirt-release last)
 - bash -x ci/start-cluster $CPLATFORM
 - bash -x ci/deploy-kubevirt $CPLATFORM
-
-

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -19,14 +19,14 @@
 
 set -ex
 
-readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
+readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt"
 
 export RHEL_NFS_DIR=${RHEL_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/$TARGET}
 export lock_name="download_${TARGET}_image.lock"
 export RHEL_LOCK_PATH=${RHEL_LOCK_PATH:-/var/lib/stdci/shared/$lock_name}
 export WINDOWS_NFS_DIR=${WINDOWS_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/$TARGET}
 export WINDOWS_LOCK_PATH=${WINDOWS_LOCK_PATH:-/var/lib/stdci/shared/$lock_name}
-export KUBEVIRT_MEMORY_SIZE=16384M
+export KUBEVIRT_MEMORY_SIZE=19384M
 export KUBEVIRT_PROVIDER="os-3.11.0"
 
 _curl() {
@@ -145,7 +145,7 @@ if [[ $TARGET =~ windows.* ]]; then
   fi
 
   if [[ $TARGET =~ windows2019.* ]]; then
-    win_image_url="${TEMPLATES_SERVER}/win_19.img"
+    win_image_url="${TEMPLATES_SERVER}/win_19_2.qcow2"
   fi
 
   if [[ $TARGET =~ windows10.* ]]; then


### PR DESCRIPTION
changed size of os-3.11 cluster
changed win 2019 image name
disable rtc timer for win 2019 test. 

These changes are needed, because win 2019 have higher claims.

Signed-off-by: Karel Simon <ksimon@redhat.com>