### PR TITLE
Revert #129

### DIFF
--- a/automation/test-rhel.sh
+++ b/automation/test-rhel.sh
@@ -64,10 +64,6 @@ if [[ $TARGET =~ rhel6.* ]]; then
   workloads=("desktop" "server")
 fi
 
-if [[ $TARGET =~ rhel8.* ]]; then
-  sizes=("small" "medium" "large")
-fi
-
 delete_vm(){
   vm_name=$1
   template_path=$2

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -17,6 +17,9 @@
       src: rhel7.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
+    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: tiny, workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True, tablet: False}
     - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False}
     - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: small, workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True, tablet: False}


### PR DESCRIPTION
This PR reverts #129. Templates cannot be deleted, because of backward compatibility (https://github.com/kubevirt/common-templates/blob/master/templates/README.md#template-edits).

Signed-off-by: Karel Simon <ksimon@redhat.com>