### PR TITLE
increased minimum required memory for tiny rhel 8 template

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -17,9 +17,9 @@
       src: rhel7.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False}
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True}
-    - {flavor: tiny, workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True, tablet: False}
+    - {flavor: tiny, workload: server, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: tiny, workload: desktop, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: tiny, workload: highperformance, memsize: "1.5Gi", cpus: 1, iothreads: True, tablet: False}
     - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False}
     - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: small, workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True, tablet: False}


### PR DESCRIPTION
Latest osinfo-db increased minimum required memory for rhel 8.
This PR increases minimum memory to 1.5Gi for rhel 8 tiny templates

Signed-off-by: Karel Simon <ksimon@redhat.com>