### PR TITLE
remove win 10 label from windows template

### DIFF
--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -87,7 +87,7 @@ _oc exec -it winrmcli -- yum install -y iproute iputils net-tools arp-scan
 kubeconfig=$( cluster-up/kubeconfig.sh )
 
 sizes=("medium" "large")
-workloads=("server" "desktop")
+workloads=("server")
 
 if [[ $TARGET =~ windows10.* ]]; then
   template_name="windows10"

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -219,9 +219,7 @@
       dest: "{{ playbook_dir }}/dist/templates/windows-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
     - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True}
     vars:
       osinfoname: win2k12r2
 

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -31,7 +31,6 @@ metadata:
     name.os.template.kubevirt.io/win2k12r2: {{ lookup('osinfo', 'win2k12r2').name }}
     name.os.template.kubevirt.io/win2k8r2: {{ lookup('osinfo', 'win2k8r2').name }}
     name.os.template.kubevirt.io/win2k8: {{ lookup('osinfo', 'win2k8').name }}
-    name.os.template.kubevirt.io/win10: {{ lookup('osinfo', 'win10').name }}
 
     validations: |
       [


### PR DESCRIPTION
remove win 10 label from windows template (there is separate win10 template)

remove desktop workload from windows template (windows template
contains only server editions)

Signed-off-by: Karel Simon <ksimon@redhat.com>