### PR TITLE
remove win-10 label from windows server template

### DIFF
--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -62,7 +62,6 @@ metadata:
     os.template.kubevirt.io/win2k12r2: "true"
     os.template.kubevirt.io/win2k8r2: "true"
     os.template.kubevirt.io/win2k8: "true"
-    os.template.kubevirt.io/win10: "true"
     workload.template.kubevirt.io/{{ item.workload }}: "true"
     flavor.template.kubevirt.io/{{ item.flavor }}: "true"
     template.kubevirt.io/type: "base"


### PR DESCRIPTION
Previous PR (https://github.com/kubevirt/common-templates/pull/136) removed only annotation
Signed-off-by: Karel Simon <ksimon@redhat.com>