### PR TITLE
change name.os.template.kubevirt.io annotation

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -16,7 +16,7 @@
       /objects[0].spec.template.spec.networks
 
 {% for osl in oslabels %}
-    name.os.template.kubevirt.io/{{ osl }}: {{ lookup('osinfo', osl).name }}
+    name.os.template.kubevirt.io/{{ osl }}: {{ lookup('osinfo', oslabels[0]).name }} or higher VM
 {% endfor %}
 
     validations: |


### PR DESCRIPTION
For UI purposes this PR changes name.os.template.kubevirt.io annotation to be in format: name.os.template.kubevirt.io/<os_short_name>: <os_nice_name> or higher VM

Signed-off-by: Karel Simon <ksimon@redhat.com>