### PR TITLE
Hide VM templates from the developer catalog

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       CentOS 6 and newer.
       The template assumes that a PVC is available which is providing the
       necessary CentOS disk image.
-    tags: "kubevirt,virtualmachine,linux,centos"
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
 
 {% set diskbus = diskbus |default("sata") %}
 

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       CentOS 7 and newer.
       The template assumes that a PVC is available which is providing the
       necessary CentOS disk image.
-    tags: "kubevirt,virtualmachine,linux,centos"
+    tags: "hidden,kubevirt,virtualmachine,linux,centos"
 
 {% include "_linux.yaml" %}
 

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -12,7 +12,7 @@ metadata:
 
       Recommended disk image (needs to be converted to raw)
       https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2
-    tags: "kubevirt,virtualmachine,fedora,rhel"
+    tags: "hidden,kubevirt,virtualmachine,fedora,rhel"
 
 {% include "_linux.yaml" %}
 

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -12,6 +12,6 @@ metadata:
 
       Recommended disk image (needs to be converted to raw)
       https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/
-    tags: "kubevirt,virtualmachine,linux,opensuse"
+    tags: "hidden,kubevirt,virtualmachine,linux,opensuse"
 
 {% include "_linux.yaml" %}

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       Red Hat Enterprise Linux 6 and newer.
       The template assumes that a PVC is available which is providing the
       necessary RHEL disk image.
-    tags: "kubevirt,virtualmachine,linux,rhel"
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
 
 {% set diskbus = diskbus |default("sata") %}
 

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       Red Hat Enterprise Linux 7 and newer.
       The template assumes that a PVC is available which is providing the
       necessary RHEL disk image.
-    tags: "kubevirt,virtualmachine,linux,rhel"
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
 
 {% include "_linux.yaml" %}
 

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -12,6 +12,6 @@ metadata:
 
       Recommended disk image (needs to be converted to raw)
       http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
-    tags: "kubevirt,virtualmachine,ubuntu"
+    tags: "hidden,kubevirt,virtualmachine,ubuntu"
 
 {% include "_linux.yaml" %}

--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       Microsoft Windows Server 2012 R2.
       The template assumes that a PVC is available which is providing the
       necessary Windows disk image.
-    tags: "kubevirt,virtualmachine,windows"
+    tags: "hidden,kubevirt,virtualmachine,windows"
     iconClass: "icon-windows"
     openshift.io/provider-display-name: "KubeVirt"
     openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       Microsoft Windows Server 2012 R2 and newer.
       The template assumes that a PVC is available which is providing the
       necessary Windows disk image.
-    tags: "kubevirt,virtualmachine,windows"
+    tags: "hidden,kubevirt,virtualmachine,windows"
     iconClass: "icon-windows"
     openshift.io/provider-display-name: "KubeVirt"
     openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       Microsoft Windows 10.
       The template assumes that a PVC is available which is providing the
       necessary Windows disk image.
-    tags: "kubevirt,virtualmachine,windows"
+    tags: "hidden,kubevirt,virtualmachine,windows"
     iconClass: "icon-windows"
     openshift.io/provider-display-name: "KubeVirt"
     openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"


### PR DESCRIPTION
To instantiate a VM template, the user would have
to provide the name of PVC with the VM's disk.
Without it the template would not work.

This patch hides the VM templates from the catalog,
so users will not be confused.