### PR TITLE
hardcode kubevirt version to v0.27.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ pvs
 openshift.local.clusterup/
 common-templates*.yaml
 releases.json
-versionsrc
 ssp-operator-deploy-key

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,10 @@ addons:
 before_script:
 - pip install PyYAML
 - sudo mount --make-rshared /
-- bash -x ci/ci/extra/get-kubevirt-releases
+## FIXME - kubevirt v0.28.0 uses functionality which os-3.11.0 doesn't support
+## we need to migrate tests to use OKD/OCP - 4.*
+## For now kubevirt version is hardcoded to v0.27.0
+#- bash -x ci/ci/extra/get-kubevirt-releases
 - bash -x ci/prepare-host $CPLATFORM
 - bash -x ci/prepare-host virtctl $(bash -x ci/ci/extra/cat-kubevirt-release last)
 - bash -x ci/start-cluster $CPLATFORM

--- a/automation/test-rhel.sh
+++ b/automation/test-rhel.sh
@@ -92,6 +92,8 @@ run_vm(){
     # start vm
     ./virtctl --kubeconfig=$kubeconfig start $vm_name
 
+    sleep 10
+
     set +e
     current_time=0
     while [ $(_oc get vmi $vm_name -o json | jq -r '.status.phase') != Running ] ; do 

--- a/versionsrc
+++ b/versionsrc
@@ -1,0 +1,2 @@
+last=v0.27.0
+secondlast=v0.26.2


### PR DESCRIPTION
This change is needed, because travis tests are running on os-3.11.0 which doesn't
support kubevirt v0.28.0. We need to migrate tests to OCP/OKD 4.*

Signed-off-by: Karel Simon <ksimon@redhat.com>