### PR TITLE
Remove 'VM' postfix from linux operating systems

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -16,7 +16,7 @@
       /objects[0].spec.template.spec.networks
 
 {% for osl in oslabels %}
-    name.os.template.kubevirt.io/{{ osl }}: {{ lookup('osinfo', oslabels[0]).name }} or higher VM
+    name.os.template.kubevirt.io/{{ osl }}: {{ lookup('osinfo', oslabels[0]).name }} or higher
 {% endfor %}
 
     validations: |


### PR DESCRIPTION
For UI purposes, remove the 'VM' postfix from linux operating systems names as it doesn't look good on the dropdown list in the new VM wizard:

![Screenshot from 2020-04-16 12-58-33](https://user-images.githubusercontent.com/18301938/79453034-c52b0c00-7ff1-11ea-9706-98be4b4d4b19.png)


Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>