### PR TITLE
Add check for min memory consistency in generated templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   include:
   - stage: Tests
-    name: Check syntax of all templates
+    name: Check syntax and memory requirements of all templates
     script: bash -x travis_ci/test_syntax.sh
 
   - name: Functional test of the Fedora template

--- a/travis_ci/test_syntax.sh
+++ b/travis_ci/test_syntax.sh
@@ -27,3 +27,4 @@ for template in $templates; do
 done
 
 python3 travis_ci/check-validations.py
+python3 travis_ci/validate-min-memory-consistency.py

--- a/travis_ci/validate-min-memory-consistency.py
+++ b/travis_ci/validate-min-memory-consistency.py
@@ -1,0 +1,66 @@
+#! python
+
+import logging
+import os
+import os.path
+import yaml
+import sys
+import json
+import importlib.util
+
+sys.path.insert(1, 'lookup_plugins/')
+import osinfo
+
+def minMemoryReqForOs(os_label):
+    latest_os_info = osinfo.LookupModule().run([os_label],[])[0]
+    return latest_os_info["minimum_resources.architecture=x86_64|all.ram"]
+
+def newestOsLabel(template):
+    labels = template["metadata"]["labels"]
+    osl_pref_str = "os.template.kubevirt.io"
+    os_labels = [label for label in labels if osl_pref_str in label]
+    return max(os_labels).split('/')[-1]
+
+def minMemoryReqInTemplate(template):
+    object = template["objects"][0]
+    min_str = object["spec"]["template"]["spec"]["domain"]["resources"]["requests"]["memory"]
+    min_gi_float = float(min_str.replace("Gi",""))
+    return int(min_gi_float * (1024**3))
+
+def checkMemoryReqs(path):
+    templates = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+    for template_name in templates:
+        with open(os.path.join(path, template_name), 'r') as stream:
+            try:
+                template = yaml.safe_load(stream)
+
+                if template == None:
+                    logging.info("Empty template file: %s", template)
+                    continue
+
+                logging.info("Checking memory requirements consistency for: {}".format(template["metadata"]["name"]))
+
+                try:
+                    newest_os_label = newestOsLabel(template)
+                    actual_min_req = minMemoryReqForOs(newest_os_label)
+                    min_req_in_template = minMemoryReqInTemplate(template)
+                    if min_req_in_template < actual_min_req:
+                        raise Exception("Memory requirements for OS: {} are not compatible"
+                                        " with the requirements set in: {}".format(newest_os_label, template_name))
+
+                except Exception as e:
+                    logging.info("Minimum memory requirements validation failed")
+                    raise e
+
+            except yaml.YAMLError as exc:
+                raise exc
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Running minimum memory requirements validation in common templates")
+
+    try:
+        checkMemoryReqs("dist/templates")
+    except Exception as e:
+        logging.error(e)
+        sys.exit(1)


### PR DESCRIPTION
Currently the minimum memory requirements set in the "validation" part of the generated template
might actually be smaller than the requirements of newest minor version of the os,
this script will through an error for such a template.

IMHO a better solution should be implemented in the future, but the obvious one - setting the
minimal memory requirement to the actual OS requirement will not do since we need to keep naming consistency,
i.e. "tiny" template means a specific memory requirement throughout the system.
