### PR TITLE
remove conroe cpu model from ubuntu template

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -205,7 +205,6 @@
     - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True}
     vars:
-      cpumodel: Conroe
       os: ubuntu
       icon: ubuntu
       password: ubuntu

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.11.0
   annotations:
     openshift.io/display-name: "Ubuntu 18.04 (Xenial Xerus) VM"
     description: >-


### PR DESCRIPTION
When creating a VM using the VM Wizard in the OpenShift Web Console,
if a user choose "Ubuntu 18.04 LTS", template forces Conroe CPU model.
This result in VM being unschedulable if this CPU type is not used
in the cluster.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1837670

Signed-off-by: Karel Simon <ksimon@redhat.com>