### PR TITLE
updated requested memory for centos8 desktop/server and ubuntu tiny template

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -93,8 +93,8 @@
       src: centos8.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False}
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: tiny, workload: server, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: False}
+    - {flavor: tiny, workload: desktop, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False}
     - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False}
@@ -200,7 +200,8 @@
       src: ubuntu.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True}
+      #minimal memory requirement for ubuntu is 2Gi, for now we don't have mechanism how to deprecate template 
+    - {flavor: tiny, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True}


### PR DESCRIPTION
updated requested memory for centos8 desktop/server and ubuntu tiny template

By updating osinfo-db minimal requirements increased for centos8 and ubuntu.
Template validator will then refuse to create tiny vm due to wrong requested memory. This PR increases requested memory for centos to 1.5Gi and 2Gi for ubuntu tiny template.

Signed-off-by: Karel Simon <ksimon@redhat.com>