### PR TITLE
Align processed VM's 'vm.kubevirt.io/template' label with template's name (include the tempalte's version)

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -45,7 +45,7 @@ objects:
   metadata:
     name: ${NAME}
     labels:
-      vm.kubevirt.io/template: {{ os }}-{{ item.workload }}-{{ item.flavor }}
+      vm.kubevirt.io/template: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "CentOS 6.0+ VM"
     description: >-

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "CentOS 7.0+ VM"
     description: >-

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.11.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.11.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "CentOS 8.0+ VM"
     description: >-

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "Fedora 23+ VM"
     description: >-

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "OpenSUSE Leap 15.0 VM"
     description: >-

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM"
     description: >-

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
     description: >-

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.10.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.10.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
     description: >-

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.11.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v0.11.0
+  name: {{ os }}-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "Ubuntu 18.04 (Xenial Xerus) VM"
     description: >-

--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: win2k12r2-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: win2k12r2-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
     description: >-
@@ -81,7 +82,7 @@ objects:
   metadata:
     name: ${NAME}
     labels:
-      vm.kubevirt.io/template: win2k12r2-{{ item.workload }}-{{ item.flavor }}
+      vm.kubevirt.io/template: win2k12r2-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: windows-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: windows-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "Microsoft Windows Server 2012 R2+ VM"
     description: >-
@@ -79,7 +80,7 @@ objects:
   metadata:
     name: ${NAME}
     labels:
-      vm.kubevirt.io/template: windows-{{ item.workload }}-{{ item.flavor }}
+      vm.kubevirt.io/template: windows-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -1,7 +1,8 @@
+{% set version =  "0.7.0" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: windows10-{{ item.workload }}-{{ item.flavor }}-v0.7.0
+  name: windows10-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
   annotations:
     openshift.io/display-name: "Microsoft Windows 10 VM"
     description: >-
@@ -71,7 +72,7 @@ objects:
   metadata:
     name: ${NAME}
     labels:
-      vm.kubevirt.io/template: windows10-{{ item.workload }}-{{ item.flavor }}
+      vm.kubevirt.io/template: windows10-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}


### PR DESCRIPTION
Template version is now defined in a variable in the template file in order to include the template version in `objects.metadata.labels["vm.kubevirt.io/template"]` and allow template validator to find the template.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1816518

Signed-off-by: Omer Yahud <oyahud@redhat.com>