### PR TITLE
added bus attribute to windows cdrom validation rule

### DIFF
--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -58,7 +58,7 @@ metadata:
         }, {
           "name": "windows-cd-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
           "rule": "enum",
           "message": "cd bus has to be sata",
           "values": ["sata"]

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -57,7 +57,7 @@ metadata:
         }, {
           "name": "windows-cd-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
           "rule": "enum",
           "message": "cd bus has to be sata",
           "values": ["sata"]

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -53,7 +53,7 @@ metadata:
         }, {
           "name": "windows-cd-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
           "rule": "enum",
           "message": "cd bus has to be sata",
           "values": ["sata"]


### PR DESCRIPTION
added bus attribute to windows cdrom validation rule

This change is needed, because disk definition contains CDRom and Disk in
the same structure (see here: https://github.com/kubevirt/kubevirt/blob/b8543ba8217a93be3cd0537442e7ff16c4979c5a/staging/src/kubevirt.io/client-go/api/v1/schema.go#L427). If template contains Disk, CDRom path (.spec.template.spec.domain.devices.disks[*].cdrom)
will be presented as well. And jsonpath will then throw an error, because cdrom path exists in the structure.

Signed-off-by: Karel Simon <ksimon@redhat.com>