### PR TITLE
Ignore disk validation if there are no disks

### DIFF
--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -43,6 +43,7 @@ metadata:
         }, {
           "name": "windows-virtio-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*]",
           "rule": "enum",
           "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
           "values": ["virtio"],
@@ -50,6 +51,7 @@ metadata:
         }, {
           "name": "windows-disk-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*]",
           "rule": "enum",
           "message": "disk bus has to be either virtio or sata",
           "values": ["virtio", "sata"]

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -42,6 +42,7 @@ metadata:
         }, {
           "name": "windows-virtio-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*]",
           "rule": "enum",
           "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
           "values": ["virtio"],
@@ -49,6 +50,7 @@ metadata:
         }, {
           "name": "windows-disk-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*]",
           "rule": "enum",
           "message": "disk bus has to be either virtio or sata",
           "values": ["virtio", "sata"]

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -38,6 +38,7 @@ metadata:
         }, {
           "name": "windows-virtio-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*]",
           "rule": "enum",
           "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
           "values": ["virtio"],
@@ -45,6 +46,7 @@ metadata:
         }, {
           "name": "windows-disk-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*]",
           "rule": "enum",
           "message": "disk bus has to be either virtio or sata",
           "values": ["virtio", "sata"]


### PR DESCRIPTION
The validation rules for disks should only be executed
if thre are some disks.
