### PR TITLE
increase terminationGracePeriodSeconds to 30 seconds

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -165,6 +165,11 @@ git submodule update --init
 
 make generate
 
+#set terminationGracePeriodSeconds to 0
+for filename in dist/templates/*; do
+    sed -i -e 's/^\(\s*terminationGracePeriodSeconds\s*:\s*\).*/\10/' $filename
+done
+
 cp automation/connect_to_rhel_console.exp automation/kubevirtci/connect_to_rhel_console.exp
   
 cd automation/kubevirtci

--- a/templates/README.md
+++ b/templates/README.md
@@ -274,6 +274,9 @@ status:
       mac-address: AA:BB:CC:DD:EE:FF
 ```
 
+## terminationGracePeriodSeconds
+All linux templates have terminationGracePeriodSeconds set to 180 seconds, in windows templates it is set to 3600 seconds.
+
 ## Future enhancements
 
 - Parameter replacement could support numerical expressions (either in the template or during parameter definition - one parameter building on top of another)

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -91,7 +91,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
-        terminationGracePeriodSeconds: 0
+        terminationGracePeriodSeconds: 180
         networks:
         - name: default
           pod: {}

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.11.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.10.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.11.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:

--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -134,7 +134,7 @@ objects:
                 bus: usb
                 name: tablet
 {% endif %}
-        terminationGracePeriodSeconds: 0
+        terminationGracePeriodSeconds: 3600
         volumes:
         - name: rootdisk
           persistentVolumeClaim:

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -132,7 +132,7 @@ objects:
                 bus: usb
                 name: tablet
 {% endif %}
-        terminationGracePeriodSeconds: 0
+        terminationGracePeriodSeconds: 3600
         volumes:
         - name: rootdisk
           persistentVolumeClaim:

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.7.0" %}
+{% set version =  "0.11.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -124,7 +124,7 @@ objects:
                 bus: usb
                 name: tablet
 {% endif %}
-        terminationGracePeriodSeconds: 0
+        terminationGracePeriodSeconds: 3600
         volumes:
         - name: rootdisk
           persistentVolumeClaim:

--- a/travis_ci/test.sh
+++ b/travis_ci/test.sh
@@ -41,6 +41,11 @@ make generate
 # Limit required memory of large templates
 bash automation/x-limit-ram-size.sh
 
+#set terminationGracePeriodSeconds to 0
+for filename in dist/templates/*; do
+    sed -i -e 's/^\(\s*terminationGracePeriodSeconds\s*:\s*\).*/\10/' $filename
+done
+
 # Download images
 case "$name" in
 "fedora")


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1861297

//cc @omeryahud, @rmohr 

Signed-off-by: Karel Simon <ksimon@redhat.com>

**Release Note**:
```release-note
Increase terminationGracePeriodSeconds to allow guest VMs to safely shutdown before deleting the VMI pod
```