### PR TITLE
remove windows 2008 labels from windows templates

### DIFF
--- a/templates/LABELS.md
+++ b/templates/LABELS.md
@@ -62,17 +62,11 @@ identifiers](https://gitlab.com/libosinfo/osinfo-db/tree/master/data/os) from th
 
 ### Microsoft Windows
 
+- os.template.kubevirt.io/win2k19
 - os.template.kubevirt.io/win2k16
 - os.template.kubevirt.io/win2k12r2
 - os.template.kubevirt.io/win2k12
-- os.template.kubevirt.io/win2k8r2
-- os.template.kubevirt.io/win2k8
 - os.template.kubevirt.io/win10
-- os.template.kubevirt.io/win8.1
-- os.template.kubevirt.io/win8
-- os.template.kubevirt.io/win7
-- os.template.kubevirt.io/winvista
-- os.template.kubevirt.io/winxp
 
 ## Workload profiles
 

--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -28,8 +28,6 @@ metadata:
     name.os.template.kubevirt.io/win2k19: {{ lookup('osinfo', 'win2k19').name }}
     name.os.template.kubevirt.io/win2k16: {{ lookup('osinfo', 'win2k16').name }}
     name.os.template.kubevirt.io/win2k12r2: {{ lookup('osinfo', 'win2k12r2').name }}
-    name.os.template.kubevirt.io/win2k8r2: {{ lookup('osinfo', 'win2k8r2').name }}
-    name.os.template.kubevirt.io/win2k8: {{ lookup('osinfo', 'win2k8').name }}
     name.os.template.kubevirt.io/win10: {{ lookup('osinfo', 'win10').name }}
 
     validations: |
@@ -67,8 +65,6 @@ metadata:
     os.template.kubevirt.io/win2k19: "true"
     os.template.kubevirt.io/win2k16: "true"
     os.template.kubevirt.io/win2k12r2: "true"
-    os.template.kubevirt.io/win2k8r2: "true"
-    os.template.kubevirt.io/win2k8: "true"
     os.template.kubevirt.io/win10: "true"
     workload.template.kubevirt.io/{{ item.workload }}: "true"
     flavor.template.kubevirt.io/{{ item.flavor }}: "true"

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -28,8 +28,6 @@ metadata:
     name.os.template.kubevirt.io/win2k19: {{ lookup('osinfo', 'win2k19').name }}
     name.os.template.kubevirt.io/win2k16: {{ lookup('osinfo', 'win2k16').name }}
     name.os.template.kubevirt.io/win2k12r2: {{ lookup('osinfo', 'win2k12r2').name }}
-    name.os.template.kubevirt.io/win2k8r2: {{ lookup('osinfo', 'win2k8r2').name }}
-    name.os.template.kubevirt.io/win2k8: {{ lookup('osinfo', 'win2k8').name }}
 
     validations: |
       [
@@ -66,8 +64,6 @@ metadata:
     os.template.kubevirt.io/win2k19: "true"
     os.template.kubevirt.io/win2k16: "true"
     os.template.kubevirt.io/win2k12r2: "true"
-    os.template.kubevirt.io/win2k8r2: "true"
-    os.template.kubevirt.io/win2k8: "true"
     workload.template.kubevirt.io/{{ item.workload }}: "true"
     flavor.template.kubevirt.io/{{ item.flavor }}: "true"
     template.kubevirt.io/type: "base"


### PR DESCRIPTION
this OS is no longer supported
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1860817
//cc @omeryahud 
Signed-off-by: Karel Simon <ksimon@redhat.com>