### PR TITLE
Removed flavor/size labels from the deprecated windows template

### DIFF
--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -68,8 +68,6 @@ metadata:
     os.template.kubevirt.io/win2k16: "true"
     os.template.kubevirt.io/win2k12r2: "true"
     os.template.kubevirt.io/win10: "true"
-    workload.template.kubevirt.io/{{ item.workload }}: "true"
-    flavor.template.kubevirt.io/{{ item.flavor }}: "true"
     template.kubevirt.io/type: "base"
     template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
 


### PR DESCRIPTION
Fixed BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1856412

Removed the labels used to query for templates from the deprecated windows template.
If the labels are removed, the template will not show up when consumers look for a template to use for a new VM,
but, because it (the template) still exists, template validator can find it in order to use it for validation of old VMs.

Release note:

```release-note
Removed the flavor/size labels from deprecated templates so they will no longer show up when querying for templates
```
Signed-off-by: Omer Yahud <oyahud@redhat.com>