### PR TITLE
add new SRCPVCNAME and SRCPVCNAMESPACE params 

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -114,4 +114,9 @@ parameters:
 - name: PVCNAME
   description: Name of the PVC with the disk image
   required: true
-
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: '{{ oslabels | last }}'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-base-images

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -147,3 +147,9 @@ parameters:
 - name: PVCNAME
   description: Name of the PVC with the disk image
   required: true
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k19
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-base-images

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -143,3 +143,9 @@ parameters:
 - name: PVCNAME
   description: Name of the PVC with the disk image
   required: true
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win10
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-base-images


### PR DESCRIPTION
add new SRC_PVC_NAME and SRC_PVC_NAMESPACE params to all templates.

These new params are added to unblock UI. They are not used in common templates
yet. In the future they will be used for datavolume template.

```release-note
add new SRC_PVC_NAME and SRC_PVC_NAMESPACE params to all templates.
```

Signed-off-by: Karel Simon <ksimon@redhat.com>