### PR TITLE
Add default cloud users to cloud-init

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -34,6 +34,7 @@
       icon: rhel
       oslabels: "{{ rhel8_labels }}"
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: cloud-user
 
   - name: Load RHEL 7 versions
     set_fact:
@@ -61,6 +62,7 @@
       icon: rhel
       oslabels: "{{ rhel7_labels }}"
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: cloud-user
 
   - name: Load RHEL 6 versions
     set_fact:
@@ -84,6 +86,7 @@
       icon: rhel
       oslabels: "{{ rhel6_labels }}"
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: cloud-user
 
   - name: Generate CentOS 8 templates
     template:
@@ -104,6 +107,7 @@
       oslabels:
        - centos8
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: centos
 
   - name: Generate CentOS 7 templates
     template:
@@ -124,6 +128,7 @@
       oslabels:
        - centos7.0
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: centos
 
   - name: Load CentOS 6 versions
     set_fact:
@@ -143,6 +148,7 @@
       icon: centos
       oslabels: "{{ centos6_labels }}"
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: centos
 
   - name: Load Fedora versions
     set_fact:
@@ -170,6 +176,7 @@
       icon: fedora
       oslabels: "{{ fedora_labels }}"
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: fedora
 
   - name: Generate OpenSUSE templates
     template:
@@ -186,6 +193,7 @@
       oslabels:
        - opensuse15.0
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: opensuse
 
   - name: Generate Ubuntu templates
     template:
@@ -203,6 +211,7 @@
       oslabels:
        - ubuntu18.04
       osinfoname: "{{ oslabels[0] }}"
+      cloudusername: ubuntu
 
   - name: Generate Windows server templates
     template:

--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -102,6 +102,7 @@ objects:
         - cloudInitNoCloud:
             userData: |-
               #cloud-config
+              user: {{ cloudusername }}
               password: ${CLOUD_USER_PASSWORD}
               chpasswd: { expire: False }
           name: cloudinitdisk


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adding the default user to the cloud-init gives an easy way to check it

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [BZ1879483](https://bugzilla.redhat.com/show_bug.cgi?id=1879483)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add default cloud users to cloud-init
```
