### PR TITLE
Fix descriptions and update osinfo-db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 language: python
 branches:
   only:

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -9,9 +9,9 @@ metadata:
       Template for Fedora 31 VM or newer.
       A PVC with the Fedora disk image must be available.
 
-      Recommended disk image (needs to be converted to raw)
-      https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2
-    tags: "hidden,kubevirt,virtualmachine,fedora,rhel"
+      Recommended disk image:
+      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+    tags: "hidden,kubevirt,virtualmachine,fedora"
 
 {% include "_linux.yaml" %}
 

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       Template for OpenSUSE Leap 15.0 VM.
       A PVC with the OpenSUSE disk image must be available.
 
-      Recommended disk image (needs to be converted to raw)
+      Recommended disk image:
       https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/
     tags: "hidden,kubevirt,virtualmachine,linux,opensuse"
 

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -9,7 +9,7 @@ metadata:
       Template for Ubuntu 18.04 (Xenial Xerus) VM.
       A PVC with the Ubuntu disk image must be available.
 
-      Recommended disk image (needs to be converted to raw)
+      Recommended disk image:
       http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
     tags: "hidden,kubevirt,virtualmachine,ubuntu"
 


### PR DESCRIPTION
**What this PR does**:
Minor fixes in the descriptions of Linux templates. Fedora disk image URL points to latest 32 version.
Updated osinfo-db, which adds EoL time to Silverblue 30 and removes if from annotations.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1852734

```release-note
- Changed Fedora disk image URL to the latest 32 release.
- Updated osinfo-db, so Silverblue 30 annotation is removed.
```
