### PR TITLE
Removed all OS labels from deprecated template

### DIFF
--- a/templates/LABELS.md
+++ b/templates/LABELS.md
@@ -6,6 +6,12 @@ the workload a template is supposed to be used for.
 Some of them are not going to be used immediately and serve
 as examples.
 
+## Deprecated templates
+
+When a template is deprecated, the following annotation is applied to it: `template.kubevirt.io/deprecated: "true"`.
+
+The template itself is not removed for backward compatibility reasons.
+
 ## Operating systems
 
 The operating system labels must match the [libosinfo

--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -16,6 +16,7 @@ metadata:
     template.openshift.io/bindable: "false"
 
     template.kubevirt.io/version: v1alpha1
+    template.kubevirt.io/deprecated: "true"
     defaults.template.kubevirt.io/disk: rootdisk
     defaults.template.kubevirt.io/network: default
     template.kubevirt.io/editable: |
@@ -24,11 +25,6 @@ metadata:
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
-
-    name.os.template.kubevirt.io/win2k19: {{ lookup('osinfo', 'win2k19').name }}
-    name.os.template.kubevirt.io/win2k16: {{ lookup('osinfo', 'win2k16').name }}
-    name.os.template.kubevirt.io/win2k12r2: {{ lookup('osinfo', 'win2k12r2').name }}
-    name.os.template.kubevirt.io/win10: {{ lookup('osinfo', 'win10').name }}
 
     validations: |
       [
@@ -64,10 +60,6 @@ metadata:
       ]
 
   labels:
-    os.template.kubevirt.io/win2k19: "true"
-    os.template.kubevirt.io/win2k16: "true"
-    os.template.kubevirt.io/win2k12r2: "true"
-    os.template.kubevirt.io/win10: "true"
     template.kubevirt.io/type: "base"
     template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
 


### PR DESCRIPTION
Removed OS labels and annotations from the deprecated windows template in order to hide it from consumers

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
To prevent creation of new VMs from deprecated templates

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1881458
https://bugzilla.redhat.com/show_bug.cgi?id=1856412

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@rnetser @jelkosz @yaacov