### PR TITLE
Fix validation for disks

### DIFF
--- a/templates/VALIDATION.md
+++ b/templates/VALIDATION.md
@@ -290,7 +290,7 @@ kind: Template
         [
           {
             "name": "supported-bus",
-            "valid": "jsonpath::.spec.domain.devices.disks[*].disk",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
             "message": "the disk bus type must be one of the supported values",
@@ -333,7 +333,7 @@ kind: Template
         [
           {
             "name": "supported-bus",
-            "valid": "jsonpath::.spec.domain.devices.disks[*].disk",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
             "message": "the disk bus type must be one of the supported values",

--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -41,7 +41,7 @@ metadata:
         }, {
           "name": "windows-virtio-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*]",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
           "rule": "enum",
           "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
           "values": ["virtio"],
@@ -49,7 +49,7 @@ metadata:
         }, {
           "name": "windows-disk-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*]",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
           "rule": "enum",
           "message": "disk bus has to be either virtio or sata",
           "values": ["virtio", "sata"]

--- a/templates/windows.tpl.yaml
+++ b/templates/windows.tpl.yaml
@@ -40,7 +40,7 @@ metadata:
         }, {
           "name": "windows-virtio-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*]",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
           "rule": "enum",
           "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
           "values": ["virtio"],
@@ -48,7 +48,7 @@ metadata:
         }, {
           "name": "windows-disk-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*]",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
           "rule": "enum",
           "message": "disk bus has to be either virtio or sata",
           "values": ["virtio", "sata"]

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -38,7 +38,7 @@ metadata:
         }, {
           "name": "windows-virtio-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*]",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
           "rule": "enum",
           "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
           "values": ["virtio"],
@@ -46,7 +46,7 @@ metadata:
         }, {
           "name": "windows-disk-bus",
           "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
-          "valid": "jsonpath::.spec.domain.devices.disks[*]",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
           "rule": "enum",
           "message": "disk bus has to be either virtio or sata",
           "values": ["virtio", "sata"]


### PR DESCRIPTION
**What this PR does / why we need it**:
The "valid" JSON path has to point to the "bus" field,
because "disk" field always exists, even if it is "nil".


**Which issue(s) this PR fixes**:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1883468

**Release note**:
```release-note
Fix validation rules for disk bus.
```
