### PR TITLE
[release-v0.12] Generate additional Windows Server templates specific to Windows server editions 2k12…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ jobs:
   - name: Functional test of the CentOS 6 template
     script: bash -x travis_ci/test.sh centos6 server
 
+  - name: Ensure that a single template is exposed for each template variant (os/workload/size trio)
+    script: bash -x travis_ci/test_duplicate_templates.sh
+
   - stage: Build and Deploy
     name: Build and Deploy to GitHub
     before_script: skip

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -6,7 +6,7 @@ _oc() {
   cluster-up/kubectl.sh "$@"
 }
 
-template_name="windows"
+template_name="windows2k12r2"
 # Prepare PV and PVC for Windows testing
 
 _oc create -f - <<EOF
@@ -92,6 +92,10 @@ workloads=("server")
 if [[ $TARGET =~ windows10.* ]]; then
   template_name="windows10"
   workloads=("desktop")
+elif [[ $TARGET =~ windows2016.* ]]; then
+  template_name="windows2k16"
+elif [[ $TARGET =~ windows2019.* ]]; then
+  template_name="windows2k19"
 fi
 
 delete_vm(){

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -222,15 +222,45 @@
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: ubuntu
 
-  - name: Generate Windows server templates
+  - name: Generate deprecated Windows server templates
     template:
-      src: windows.tpl.yaml
+      src: deprecated-windows.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
     - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True}
     - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True}
     vars:
       osinfoname: win2k12r2
+
+  - name: Generate Windows server 2012 R2 templates
+    template:
+      src: windows2k12.tpl.yaml
+      dest: "{{ playbook_dir }}/dist/templates/windows2k12r2-{{ item.workload }}-{{ item.flavor }}.yaml"
+    with_items:
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True}
+    vars:
+      osinfoname: win2k12r2
+
+  - name: Generate Windows server 2016 templates
+    template:
+      src: windows2k16.tpl.yaml
+      dest: "{{ playbook_dir }}/dist/templates/windows2k16-{{ item.workload }}-{{ item.flavor }}.yaml"
+    with_items:
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True}
+    vars:
+      osinfoname: win2k16
+
+  - name: Generate Windows server 2019 templates
+    template:
+      src: windows2k19.tpl.yaml
+      dest: "{{ playbook_dir }}/dist/templates/windows2k19-{{ item.workload }}-{{ item.flavor }}.yaml"
+    with_items:
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True}
+    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True}
+    vars:
+      osinfoname: win2k19
 
   - name: Generate Windows 10 templates
     template:

--- a/templates/deprecated-windows.tpl.yaml
+++ b/templates/deprecated-windows.tpl.yaml
@@ -1,4 +1,4 @@
-{% set version =  "0.11.3" %}
+{% set version =  "0.12.3" %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -16,6 +16,7 @@ metadata:
     template.openshift.io/bindable: "false"
 
     template.kubevirt.io/version: v1alpha1
+    template.kubevirt.io/deprecated: "true"
     defaults.template.kubevirt.io/disk: rootdisk
     defaults.template.kubevirt.io/network: default
     template.kubevirt.io/editable: |
@@ -24,10 +25,6 @@ metadata:
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
-
-    name.os.template.kubevirt.io/win2k19: {{ lookup('osinfo', 'win2k19').name }}
-    name.os.template.kubevirt.io/win2k16: {{ lookup('osinfo', 'win2k16').name }}
-    name.os.template.kubevirt.io/win2k12r2: {{ lookup('osinfo', 'win2k12r2').name }}
 
     validations: |
       [
@@ -63,11 +60,6 @@ metadata:
       ]
 
   labels:
-    os.template.kubevirt.io/win2k19: "true"
-    os.template.kubevirt.io/win2k16: "true"
-    os.template.kubevirt.io/win2k12r2: "true"
-    workload.template.kubevirt.io/{{ item.workload }}: "true"
-    flavor.template.kubevirt.io/{{ item.flavor }}: "true"
     template.kubevirt.io/type: "base"
     template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
 

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -1,0 +1,151 @@
+{% set version =  "0.12.3" %}
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k12r2-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
+    description: >-
+      Template for Microsoft Windows Server 2012 R2 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.kubevirt.io/win2k12r2: {{ lookup('osinfo', 'win2k12r2').name }}
+
+    validations: |
+      [
+        {
+          "name": "minimal-required-memory",
+          "path": "jsonpath::.spec.domain.resources.requests.memory",
+          "rule": "integer",
+          "message": "This VM requires more memory.",
+          "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
+        }, {
+          "name": "windows-virtio-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "rule": "enum",
+          "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+          "values": ["virtio"],
+          "justWarning": true
+        }, {
+          "name": "windows-disk-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "rule": "enum",
+          "message": "disk bus has to be either virtio or sata",
+          "values": ["virtio", "sata"]
+        }, {
+          "name": "windows-cd-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+          "rule": "enum",
+          "message": "cd bus has to be sata",
+          "values": ["sata"]
+        }
+      ]
+
+  labels:
+    os.template.kubevirt.io/win2k12r2: "true"
+    workload.template.kubevirt.io/{{ item.workload }}: "true"
+    flavor.template.kubevirt.io/{{ item.flavor }}: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k12r2-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
+      vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+      vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      metadata:
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: {{ item.flavor }}
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: {{ item.cpus }}
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: {{ item.memsize }}
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              spinlocks:
+                spinlocks: 8191
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: rootdisk
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+{% if item.tablet %}
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+{% endif %}
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        networks:
+        - name: default
+          pod: {}
+
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k12r2
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -1,0 +1,151 @@
+{% set version =  "0.12.3" %}
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k16-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2016 VM"
+    description: >-
+      Template for Microsoft Windows Server 2016 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.kubevirt.io/win2k16: {{ lookup('osinfo', 'win2k16').name }}
+
+    validations: |
+      [
+        {
+          "name": "minimal-required-memory",
+          "path": "jsonpath::.spec.domain.resources.requests.memory",
+          "rule": "integer",
+          "message": "This VM requires more memory.",
+          "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
+        }, {
+          "name": "windows-virtio-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "rule": "enum",
+          "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+          "values": ["virtio"],
+          "justWarning": true
+        }, {
+          "name": "windows-disk-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "rule": "enum",
+          "message": "disk bus has to be either virtio or sata",
+          "values": ["virtio", "sata"]
+        }, {
+          "name": "windows-cd-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+          "rule": "enum",
+          "message": "cd bus has to be sata",
+          "values": ["sata"]
+        }
+      ]
+
+  labels:
+    os.template.kubevirt.io/win2k16: "true"
+    workload.template.kubevirt.io/{{ item.workload }}: "true"
+    flavor.template.kubevirt.io/{{ item.flavor }}: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k16-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
+      vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+      vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      metadata:
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: {{ item.flavor }}
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: {{ item.cpus }}
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: {{ item.memsize }}
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              spinlocks:
+                spinlocks: 8191
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: rootdisk
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+{% if item.tablet %}
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+{% endif %}
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        networks:
+        - name: default
+          pod: {}
+
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k16
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -1,0 +1,151 @@
+{% set version =  "0.12.3" %}
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows2k19-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2019 VM"
+    description: >-
+      Template for Microsoft Windows Server 2019 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+
+    name.os.template.kubevirt.io/win2k19: {{ lookup('osinfo', 'win2k19').name }}
+
+    validations: |
+      [
+        {
+          "name": "minimal-required-memory",
+          "path": "jsonpath::.spec.domain.resources.requests.memory",
+          "rule": "integer",
+          "message": "This VM requires more memory.",
+          "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
+        }, {
+          "name": "windows-virtio-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "rule": "enum",
+          "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+          "values": ["virtio"],
+          "justWarning": true
+        }, {
+          "name": "windows-disk-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+          "rule": "enum",
+          "message": "disk bus has to be either virtio or sata",
+          "values": ["virtio", "sata"]
+        }, {
+          "name": "windows-cd-bus",
+          "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+          "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+          "rule": "enum",
+          "message": "cd bus has to be sata",
+          "values": ["sata"]
+        }
+      ]
+
+  labels:
+    os.template.kubevirt.io/win2k19: "true"
+    workload.template.kubevirt.io/{{ item.workload }}: "true"
+    flavor.template.kubevirt.io/{{ item.flavor }}: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows2k19-{{ item.workload }}-{{ item.flavor }}-v{{ version }}
+      vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+      vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
+      app: ${NAME}
+  spec:
+    running: false
+    template:
+      metadata:
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: {{ item.flavor }}
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: {{ item.cpus }}
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: {{ item.memsize }}
+          features:
+            acpi: {}
+            apic: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              spinlocks:
+                spinlocks: 8191
+          devices:
+            disks:
+            - disk:
+                bus: sata
+              name: rootdisk
+            interfaces:
+            - masquerade: {}
+              model: e1000e
+              name: default
+{% if item.tablet %}
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+{% endif %}
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: ${PVCNAME}
+        networks:
+        - name: default
+          pod: {}
+
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: PVCNAME
+  description: Name of the PVC with the disk image
+  required: true
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: win2k19
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images

--- a/travis_ci/test_duplicate_templates.sh
+++ b/travis_ci/test_duplicate_templates.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2019 Red Hat, Inc.
+#
+set -ex
+
+make generate
+
+# Deploy templates
+echo "Deploying templates"
+oc create -f dist/templates
+
+templates=("dist/templates/*.yaml")
+for template in $templates; do
+
+	os_name_prefix="^[[:space:]]*os.template.kubevirt.io/"
+	template_oss=$(grep "$os_name_prefix" $template | cut -f1 -d":")
+
+	workload_prefix="workload.template.kubevirt.io/"
+	template_workloads=$(grep "$workload_prefix" $template | cut -f1 -d":")
+
+	flavor_prefix="flavor.template.kubevirt.io/"
+	template_flavors=$(grep "$flavor_prefix" $template | cut -f1 -d":")
+
+	for os in $template_oss; do
+		for workload in $template_workloads; do
+			for flavor in $template_flavors; do
+				count=$(oc get template -l $os,$workload,$flavor --no-headers | wc -l)
+				if [[ $count -ne 1 ]]; then
+					echo "There are $count templates found with the following labels $os,$workload,$flavor"
+					exit 1
+				fi
+			done
+		done
+	done
+done


### PR DESCRIPTION
Generate additional Windows Server templates specific to Windows 2k12R2, Windows 2k16 and Windows 2k19

Signed-off-by: Omer Yahud <oyahud@redhat.com>

/cc @shwetaap 
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://github.com/kubevirt/common-templates/pull/242

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I had to manually backport this as kuebvirt-bot encountered conflicts
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
