### PR TITLE
Updated the fedora image

### DIFF
--- a/travis_ci/test.sh
+++ b/travis_ci/test.sh
@@ -49,7 +49,7 @@ done
 # Download images
 case "$name" in
 "fedora")
-	curl -fL -o "$name" https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2
+	curl -fL -o "$name" https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
     ;;
 "ubuntu")
 	curl -fL -o "$name" http://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img


### PR DESCRIPTION
Updated the fedora image since travis cannot download the old one (gets 404) for an unknown reason

Signed-off-by: Omer Yahud <oyahud@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fedora image was updated to 32 in CI
```
