### PR TITLE
enable Hyper-V flags

### DIFF
--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -128,8 +128,15 @@ objects:
             hyperv:
               relaxed: {}
               vapic: {}
+              vpindex: {}
               spinlocks:
                 spinlocks: 8191
+              synic: {}
+              synictimer: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
           devices:
             disks:
             - disk:

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -137,6 +137,8 @@ objects:
               frequencies: {}
               reenlightenment: {}
               ipi: {}
+              runtime: {}
+              reset: {}
           devices:
             disks:
             - disk:

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -128,8 +128,15 @@ objects:
             hyperv:
               relaxed: {}
               vapic: {}
+              vpindex: {}
               spinlocks:
                 spinlocks: 8191
+              synic: {}
+              synictimer: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
           devices:
             disks:
             - disk:

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -137,6 +137,8 @@ objects:
               frequencies: {}
               reenlightenment: {}
               ipi: {}
+              runtime: {}
+              reset: {}
           devices:
             disks:
             - disk:

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -128,8 +128,15 @@ objects:
             hyperv:
               relaxed: {}
               vapic: {}
+              vpindex: {}
               spinlocks:
                 spinlocks: 8191
+              synic: {}
+              synictimer: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
           devices:
             disks:
             - disk:

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -137,6 +137,8 @@ objects:
               frequencies: {}
               reenlightenment: {}
               ipi: {}
+              runtime: {}
+              reset: {}
           devices:
             disks:
             - disk:

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -128,8 +128,15 @@ objects:
             hyperv:
               relaxed: {}
               vapic: {}
+              vpindex: {}
               spinlocks:
                 spinlocks: 8191
+              synic: {}
+              synictimer: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
           devices:
             disks:
             - disk:

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -137,6 +137,8 @@ objects:
               frequencies: {}
               reenlightenment: {}
               ipi: {}
+              runtime: {}
+              reset: {}
           devices:
             disks:
             - disk:


### PR DESCRIPTION
This is the test to see, if our new CI can handle hyper-v  (previously Francesco tried it https://github.com/kubevirt/common-templates/pull/70)

**What this PR does / why we need it**:
enable Hyper-V flags vpindex, synic, synictimer, tlbflush, frequencies, reenlightenment, ipi
Other hyper-v flags are not allowed:
evmcs: depends on KVM capability (currently vm with this flag will not run)
stimer: disabled in kubevirt
**Release note**:
```
Enable Hyper-V flags (vpindex, synic, synictimer, tlbflush, frequencies, reenlightenment, ipi)
```
Signed-off-by: Karel Simon <ksimon@redhat.com>