### PR TITLE
[Bugfix] Locked the version of the deprecated templates

### DIFF
--- a/automation/test_duplicate_templates.sh
+++ b/automation/test_duplicate_templates.sh
@@ -18,6 +18,10 @@
 #
 set -ex
 
+ver_label='^[[:space:]]*template.kubevirt.io/version'
+# Any template can be used here as they all have the same verison label, centos is an arbitrary one
+ver_value=$(grep "$ver_label" dist/templates/centos6-server-large.yaml | tail -1 | cut -f2 -d":" | tr -d ' "')
+ver_label="template.kubevirt.io/version=$ver_value"
 templates=("dist/templates/*.yaml")
 for template in $templates; do
 
@@ -33,9 +37,9 @@ for template in $templates; do
 	for os in $template_oss; do
 		for workload in $template_workloads; do
 			for flavor in $template_flavors; do
-				count=$(oc get template -n kubevirt -l $os,$workload,$flavor --no-headers | wc -l)
+				count=$(oc get template -l $os,$workload,$flavor,$ver_label --no-headers | wc -l)
 				if [[ $count -ne 1 ]]; then
-					echo "There are $count templates found with the following labels $os,$workload,$flavor"
+					echo "There are $count templates found with the following labels $os,$workload,$flavor,$ver_label"
 					exit 1
 				fi
 			done

--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -5,13 +5,22 @@ make generate
 #syntax check
 templates=($(grep -L "template.kubevirt.io/deprecated: \"true\"" dist/templates/*))
 namespace="kubevirt"
-oc create namespace $namespace
+
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}
+EOF
+
+oc project $namespace
 
 for template in $templates; do
-    oc process -f "$template" -n $namespace NAME=test SRC_PVC_NAME=test || exit 1;
+    oc process -f "$template" NAME=test SRC_PVC_NAME=test || exit 1;
 done
 
-oc create -n $namespace -f dist/templates
+echo "Testing fresh installation..."
+oc create -f dist/templates
 
 #check validation part
 python3 automation/check-validations.py
@@ -27,14 +36,23 @@ if [ $? -eq 1 ];then
   exit 1
 fi
 
+echo "Testing upgrade..."
+oc delete -f dist/templates
+
+LATEST_CT=$(curl -L https://api.github.com/repos/kubevirt/common-templates/releases | \
+            jq '.[] | select(.prerelease==false) | .name' | sort -V | tail -n1 | tr -d '"')
+oc apply -f https://github.com/kubevirt/common-templates/releases/download/${LATEST_CT}/common-templates-${LATEST_CT}.yaml
+
+oc apply -f dist/templates
+
 ./automation/test_duplicate_templates.sh
 if [ $? -eq 1 ];then
-  echo "Validation of duplicate templates failed "
+  echo "[Upgrade] Validation of duplicate templates failed "
   exit 1
 fi
 
 ./automation/test_defaults.sh 
 if [ $? -eq 1 ];then
-  echo "Validation of default label failed "
+  echo "[Upgrade] Validation of default label failed "
   exit 1
 fi

--- a/templates/deprecated-windows.tpl.yaml
+++ b/templates/deprecated-windows.tpl.yaml
@@ -61,10 +61,8 @@ metadata:
 
   labels:
     template.kubevirt.io/type: "base"
-    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
-{% if item.default %}
-    template.kubevirt.io/default-os-variant: "true"
-{% endif %}
+    # Locking the template version as it is deprecated and should not receive any more updates
+    template.kubevirt.io/version: "v{{ version }}"
 
 objects:
 - apiVersion: kubevirt.io/v1alpha3

--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -61,10 +61,8 @@ metadata:
 
   labels:
     template.kubevirt.io/type: "base"
-    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
-{% if item.default %}
-    template.kubevirt.io/default-os-variant: "true"
-{% endif %}
+    # Locking the template version as it is deprecated and should not receive any more updates
+    template.kubevirt.io/version: "v{{ version }}"
 
 objects:
 - apiVersion: kubevirt.io/v1alpha3


### PR DESCRIPTION
Locked the version of the deprecated templates so they do not show up in the UI when the latest version is queried for

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
During an upgrade from previous template versions, the deprecated templates do not lose their labels (because the operator cannot remove those labels), so in order to exclude them from the UI view, I have locked their version to an older version, so they do not show up when the UI queries for the latest templates version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1899460

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
