### PR TITLE
Add annotations for VirtualMachines

### DIFF
--- a/templates/_linux.yaml
+++ b/templates/_linux.yaml
@@ -52,6 +52,10 @@ objects:
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
+    annotations:
+      vm.kubevirt.io/os: "{{ os }}"
+      vm.kubevirt.io/workload: "{{ item.workload }}"
+      vm.kubevirt.io/flavor: "{{ item.flavor }}"
   spec:
     dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -80,6 +80,10 @@ objects:
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
+    annotations:
+      vm.kubevirt.io/os: "windows10"
+      vm.kubevirt.io/workload: "{{ item.workload }}"
+      vm.kubevirt.io/flavor: "{{ item.flavor }}"
   spec:
     dataVolumeTemplates:
       - apiVersion: cdi.kubevirt.io/v1beta1

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -80,6 +80,10 @@ objects:
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
+    annotations:
+      vm.kubevirt.io/os: "windows2k12r2"
+      vm.kubevirt.io/workload: "{{ item.workload }}"
+      vm.kubevirt.io/flavor: "{{ item.flavor }}"
   spec:
     dataVolumeTemplates:
       - apiVersion: cdi.kubevirt.io/v1beta1

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -80,6 +80,10 @@ objects:
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
+    annotations:
+      vm.kubevirt.io/os: "windows2k16"
+      vm.kubevirt.io/workload: "{{ item.workload }}"
+      vm.kubevirt.io/flavor: "{{ item.flavor }}"
   spec:
     dataVolumeTemplates:
       - apiVersion: cdi.kubevirt.io/v1beta1

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -80,6 +80,10 @@ objects:
       vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
+    annotations:
+      vm.kubevirt.io/os: "windows2k19"
+      vm.kubevirt.io/workload: "{{ item.workload }}"
+      vm.kubevirt.io/flavor: "{{ item.flavor }}"
   spec:
     dataVolumeTemplates:
       - apiVersion: cdi.kubevirt.io/v1beta1


### PR DESCRIPTION
The os, workload and flavor annotations are added to VirtualMachines in
order to expose them in the kubevirt_vmi_phase_count metric.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add os, workload and flavor annotations to VirtualMachine
```
