### PR TITLE
[release-v0.12] [Bugfix] Lock deprecated versions

### DIFF
--- a/templates/deprecated-windows.tpl.yaml
+++ b/templates/deprecated-windows.tpl.yaml
@@ -61,7 +61,8 @@ metadata:
 
   labels:
     template.kubevirt.io/type: "base"
-    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+    # Locking the template version as it is deprecated and should not receive any more updates
+    template.kubevirt.io/version: "v{{ version }}"
 
 objects:
 - apiVersion: kubevirt.io/v1alpha3

--- a/templates/win2k12r2-deprecated.tpl.yaml
+++ b/templates/win2k12r2-deprecated.tpl.yaml
@@ -61,7 +61,8 @@ metadata:
 
   labels:
     template.kubevirt.io/type: "base"
-    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+    # Locking the template version as it is deprecated and should not receive any more updates
+    template.kubevirt.io/version: "v{{ version }}"
 
 objects:
 - apiVersion: kubevirt.io/v1alpha3


### PR DESCRIPTION
Lock deprecated versions in the UI when the latest version is queried for

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1899460

Signed-off-by: Omer Yahud <oyahud@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
