### PR TITLE
use rtl8139 interface model on rhel6 and centos6

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -102,7 +102,6 @@ objects:
               memory: {{ item.memsize }}
           devices:
             rng: {}
-            networkInterfaceMultiqueue: true
 {% if item.tablet %}
             inputs:
               - type: tablet
@@ -119,6 +118,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: rtl8139
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -102,7 +102,6 @@ objects:
               memory: {{ item.memsize }}
           devices:
             rng: {}
-            networkInterfaceMultiqueue: true
 {% if item.tablet %}
             inputs:
               - type: tablet
@@ -119,6 +118,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: rtl8139
         terminationGracePeriodSeconds: 180
         networks:
         - name: default


### PR DESCRIPTION
rhel6 does not support the virtio interface model, which is kubevirt's
default. This change sets the interface model to rtl8139 explicitly on
rhel6, which is known to work there. It drops networkInterfaceMultiqueue
as it has no virtio device to apply on.

Bug-URL: https://bugzilla.redhat.com/show_bug.cgi?id=1794243
Signed-off-by: Dan Kenigsberg <danken@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMs created based on the rhel6 or centos6 templates can communicate over the pod network with no need to select non-virtio model.
```
