### PR TITLE
rhel6: use e1000e instead of rtl8139

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -118,7 +118,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
-              model: rtl8139
+              model: e1000e
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -118,7 +118,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
-              model: rtl8139
+              model: e1000e
         terminationGracePeriodSeconds: 180
         networks:
         - name: default


### PR DESCRIPTION
e1000e is supposed to be faster. More importantly it is available in the
KubeVirt console, and reported to work just as well with rhel6 in
https://bugzilla.redhat.com/show_bug.cgi?id=1794243#c8

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use `e1000e` interface model on RHEL6 to conform with OpenShift console available models
```
