### PR TITLE
Explain why Windows grace period is so long

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -284,7 +284,9 @@ status:
 ```
 
 ## terminationGracePeriodSeconds
-All linux templates have terminationGracePeriodSeconds set to 180 seconds, in windows templates it is set to 3600 seconds.
+All Linux templates have terminationGracePeriodSeconds set to 180 seconds.
+In Windows templates it is set to 3600 seconds (1 hour) to reduce the
+probability of an ungraceful shutting down of a Windows VM during update.
 
 ## Future enhancements
 


### PR DESCRIPTION
Explain why Windows grace period is so long

commit 7127e2fd0 has set terminationGracePeriodSeconds for Windows
template on 3600 seconds, or one whole hour. I find it way too long, so
document the reason behind it. 

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
