### PR TITLE
Add emulator thread

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -17,18 +17,18 @@
       src: rhel8.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: tiny, workload: highperformance, memsize: "1.5Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True, tablet: False, default: False}
+    - {flavor: tiny,   workload: server,          memsize: "1.5Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop,         memsize: "1.5Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: tiny,   workload: highperformance, memsize: "1.5Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: small,  workload: server,          memsize: "2Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop,         memsize: "2Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: highperformance, memsize: "2Gi",   cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop,         memsize: "4Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi",   cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi",   cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop,         memsize: "8Gi",   cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi",   cpus: 2, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
     vars:
       os: rhel8
       icon: rhel
@@ -46,18 +46,18 @@
       src: rhel7.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: tiny, workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True, tablet: False, default: False}
+    - {flavor: tiny,   workload: server,          memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop,         memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: tiny,   workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: small,  workload: server,          memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop,         memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop,         memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop,         memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
     vars:
       os: rhel7
       icon: rhel
@@ -75,14 +75,14 @@
       src: rhel6.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: tiny,   workload: server,  memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: server,  memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: server,  memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: server,  memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
     vars:
       os: rhel6
       icon: rhel
@@ -96,14 +96,14 @@
       src: centos8.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: tiny,   workload: server,  memsize: "1.5Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop, memsize: "1.5Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: server,  memsize: "2Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop, memsize: "2Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: server,  memsize: "4Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop, memsize: "4Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: server,  memsize: "8Gi",   cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi",   cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
     vars:
       os: centos8
       icon: centos
@@ -118,14 +118,14 @@
       src: centos7.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: tiny,   workload: server,  memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: server,  memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: server,  memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: server,  memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
     vars:
       os: centos7
       icon: centos
@@ -144,10 +144,10 @@
       src: centos6.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: server, memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: small,  workload: server, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
     vars:
       os: centos6
       icon: centos
@@ -165,18 +165,18 @@
       src: fedora.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop,         memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: tiny,   workload: server,          memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: small,  workload: desktop,         memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: server,          memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: medium, workload: desktop,         memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: large,  workload: desktop,         memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
     vars:
       os: fedora
       icon: fedora
@@ -190,10 +190,10 @@
       src: opensuse.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: server, memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: small,  workload: server, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
     vars:
       os: opensuse
       icon: opensuse
@@ -209,10 +209,10 @@
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
       #minimal memory requirement for ubuntu is 2Gi, for now we don't have mechanism how to deprecate template
-    - {flavor: tiny, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: tiny,   workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: False}
+    - {flavor: small,  workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
     vars:
       os: ubuntu
       icon: ubuntu
@@ -227,8 +227,8 @@
       src: windows2k12.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k12r2-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
     vars:
       osinfoname: win2k12r2
 
@@ -237,8 +237,8 @@
       src: windows2k16.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k16-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
     vars:
       osinfoname: win2k16
 
@@ -247,8 +247,8 @@
       src: windows2k19.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k19-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
     vars:
       osinfoname: win2k19
 
@@ -258,6 +258,6 @@
       dest: "{{ playbook_dir }}/dist/templates/windows10-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
     - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
     vars:
       osinfoname: win10

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -98,6 +98,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
+{% if item.emulatorthread %}
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+{% endif %}
           resources:
             requests:
               memory: {{ item.memsize }}

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -96,6 +96,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
+{% if item.emulatorthread %}
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+{% endif %}
           resources:
             requests:
               memory: {{ item.memsize }}

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -96,6 +96,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
+{% if item.emulatorthread %}
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+{% endif %}
           resources:
             requests:
               memory: {{ item.memsize }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: This PR adds emulator thread pinning to high performance templates.

**Special notes for your reviewer**:
- added `emulatorthread` item to `generate-templates.yaml` and corresponding logic to `.tpl.yaml` files control template generation;
- emulator thread pinning requires dedicated CPU placement; current logic adds both options using the same item;
- platforms that do not specify a high performance template did not have their `.tpl.yaml` files modified;
- as an "extra" modification, this PR also reformats `generate-templates.yaml` to align item configuration;

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
