### PR TITLE
validate pvc name and namespace stability across upgrades

### DIFF
--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -43,6 +43,15 @@ LATEST_CT=$(curl -L https://api.github.com/repos/kubevirt/common-templates/relea
             jq '.[] | select(.prerelease==false) | .name' | sort -V | tail -n1 | tr -d '"')
 oc apply -f https://github.com/kubevirt/common-templates/releases/download/${LATEST_CT}/common-templates-${LATEST_CT}.yaml
 
+set +e
+python3 automation/validate-pvc-name-stability.py
+RC=${?}
+set -e
+if [ ${RC} -ne 0 ];then
+  echo "[Upgrade] Validation of PVC name stability failed"
+  exit ${RC}
+fi
+
 oc apply -f dist/templates
 
 ./automation/test_duplicate_templates.sh

--- a/automation/validate-pvc-name-stability.py
+++ b/automation/validate-pvc-name-stability.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+import logging
+import os
+import os.path
+import yaml
+import sys
+
+from kubernetes import client, config
+from openshift.dynamic import DynamicClient
+
+
+def validatePVCNames(path, liveTemplates):
+    templates = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+    errors = []
+    for templateFilename in templates:
+        with open(os.path.join(path, templateFilename), 'r') as stream:
+            template = yaml.safe_load(stream)
+
+            if template is None:
+                errors.append("Empty template file: {}".format(templateFilename))
+                continue
+
+            templateName = template["metadata"]["name"]
+            logging.info("Checking PVC name stability for: {}".format(templateName))
+
+            pvcName = getPVCNameFrom(template)
+            pvcNamespace = getPVCNamespaceFrom(template)
+
+            matchingLiveTemplate = liveTemplates.get(templateName)
+            if matchingLiveTemplate:
+                liveTemplatePVCName = getPVCNameFrom(matchingLiveTemplate)
+                liveTemplatePVCNamespace = getPVCNamespaceFrom(matchingLiveTemplate)
+
+                if pvcName != liveTemplatePVCName:
+                    errors.append("PVC name: {} was modified in: {}".format(pvcName, templateName))
+                if pvcNamespace != liveTemplatePVCNamespace:
+                    errors.append("PVC namespace: {} was modified in: {}".format(pvcNamespace, templateName))
+            else:
+                logging.info("Missing liveTemplate for {}".format(templateName))
+
+    if errors:
+        error_message = "\n".join(errors)
+        logging.info("PVC stability vaidation failed")
+        raise Exception(error_message)
+
+
+def getParamFrom(template, paramName):
+    for param in template["parameters"]:
+        if param["name"] == paramName:
+            return param["value"]
+    return None
+
+
+def getPVCNameFrom(template):
+    return getParamFrom(template, "SRC_PVC_NAME")
+
+
+def getPVCNamespaceFrom(template):
+    return getParamFrom(template, "SRC_PVC_NAMESPACE")
+
+
+def fetchLiveTemplates():
+    k8s_client = config.new_client_from_config()
+    dyn_client = DynamicClient(k8s_client)
+
+    template_v1 = dyn_client.resources.get(api_version='template.openshift.io/v1', kind='Template')
+    templates = template_v1.get()
+
+    if not templates:
+        return {}
+
+    liveTemplates = {}
+    for template in templates.items:
+        liveTemplates[template["metadata"]["name"]] = template
+
+    return liveTemplates
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Running PVC name stability validation")
+
+    try:
+        liveTemplates = fetchLiveTemplates()
+        validatePVCNames("dist/templates", liveTemplates)
+    except Exception as e:
+        logging.error(e)
+        sys.exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a test to ensure `SRC_PVC_NAME` and `SRC_PVC_NAMESPACE` do not change across upgrades.

**Special notes for your reviewer**:
Right now the test relies on the template names not changing across versions. If a template gets renamed the test won't fail as it's technically not the same template anymore.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
