### PR TITLE
add support for scsi disk bus in windows validation 

### DIFF
--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -67,8 +67,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "disk bus has to be either virtio or sata",
-            "values": ["virtio", "sata"]
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
           }, {
             "name": "windows-cd-bus",
             "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -67,8 +67,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "disk bus has to be either virtio or sata",
-            "values": ["virtio", "sata"]
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
           }, {
             "name": "windows-cd-bus",
             "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -67,8 +67,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "disk bus has to be either virtio or sata",
-            "values": ["virtio", "sata"]
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
           }, {
             "name": "windows-cd-bus",
             "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -67,8 +67,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "disk bus has to be either virtio or sata",
-            "values": ["virtio", "sata"]
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
           }, {
             "name": "windows-cd-bus",
             "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",


### PR DESCRIPTION
**What this PR does / why we need it**:
When VMIO migrates a VM from RHV, it needs to be able to set the disk bus to "scsi".

This commit adds support for scsi in windows validation.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1912908

**Release note**:
```release-note
add support for scsi disk bus in windows validation 
```
Signed-off-by: Karel Simon <ksimon@redhat.com>