### PR TITLE
Adopt RHEL6 and Centos 6 templates to new libvirt/QEMU changes

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -101,6 +101,7 @@ objects:
             requests:
               memory: {{ item.memsize }}
           devices:
+            useVirtioTransitional: true
             rng: {}
 {% if item.tablet %}
             inputs:

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -101,6 +101,7 @@ objects:
             requests:
               memory: {{ item.memsize }}
           devices:
+            useVirtioTransitional: true
             rng: {}
 {% if item.tablet %}
             inputs:


### PR DESCRIPTION
Old guests like RHEL6 or CentOS6 require virtio-transitional
in newer libvirt/qemu versions, therefore a flag was added in the VM
template in order to signal the need for the virtio-transitional
configuration in the devices section.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1783192

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
