### PR TITLE
update base image for openshiftci

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,5 +1,5 @@
 #This docker file is used in openshift CI
-FROM fedora:30
+FROM quay.io/kubevirt/common-templates:fedora33CI
 
 RUN dnf install -y jq ansible libosinfo python3-gobject libosinfo intltool make git findutils qemu expect
 RUN chmod uga+w /etc/passwd


### PR DESCRIPTION
**What this PR does / why we need it**:
sometimes tests fail due to dockerhub pull restrictions. This PR updates base image to newest fedora 33 and changes location from dockerhub to quay.

/cc @omeryahud 
**Special notes for your reviewer**:

**Release note**:
```NONE

```
Signed-off-by: Karel Simon <ksimon@redhat.com>