### PR TITLE
Centos 6 and RHEL 6 to use virtio bus for network and storage by default

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -90,6 +90,8 @@ run_vm(){
     .items[0].metadata.labels["vm.kubevirt.io/template.namespace"]="kubevirt"' | \
     oc apply -n $namespace -f -
 
+    ./virtctl version
+    oc get vm $vm_name -n $namespace -oyaml
     # start vm
     ./virtctl start $vm_name -n $namespace
 

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -1,4 +1,4 @@
-{% set diskbus = diskbus |default("sata") %}
+{% set diskbus = diskbus |default("virtio") %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -119,7 +119,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
-              model: e1000e
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -101,6 +101,7 @@ objects:
             requests:
               memory: {{ item.memsize }}
           devices:
+            networkInterfaceMultiqueue: true
             useVirtioTransitional: true
             rng: {}
 {% if item.tablet %}
@@ -110,7 +111,8 @@ objects:
                 name: tablet
 {% endif %}
             disks:
-            - disk:
+            - bootOrder: 1
+              disk:
                 bus: {{ diskbus | default("virtio") }}
               name: ${NAME}
             - disk:

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -1,4 +1,4 @@
-{% set diskbus = diskbus |default("sata") %}
+{% set diskbus = diskbus |default("virtio") %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -119,7 +119,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
-              model: e1000e
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -101,6 +101,7 @@ objects:
             requests:
               memory: {{ item.memsize }}
           devices:
+            networkInterfaceMultiqueue: true
             useVirtioTransitional: true
             rng: {}
 {% if item.tablet %}
@@ -110,7 +111,8 @@ objects:
                 name: tablet
 {% endif %}
             disks:
-            - disk:
+            - bootOrder: 1
+              disk:
                 bus: {{ diskbus | default("virtio") }}
               name: ${NAME}
             - disk:


### PR DESCRIPTION
Old guests can now use virtio bus for disks and network interfaces
therefore configure the template to use that bus type as a default bus for them.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**Release note**:
```release-note
Centos 6 and RHEL 6 based images to consume virtio bus for disks and network devices
```
