### PR TITLE
add python3-openshift to builder

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,7 +1,7 @@
 #This docker file is used in openshift CI
 FROM fedora:30
 
-RUN dnf install -y jq ansible libosinfo python3-gobject libosinfo intltool make git findutils qemu expect
+RUN dnf install -y jq ansible libosinfo python3-gobject python3-openshift libosinfo intltool make git findutils qemu expect
 RUN chmod uga+w /etc/passwd
 
 #set permissions for ansible tmp folder


### PR DESCRIPTION
Signed-off-by: Kevin Wiesmueller <kwiesmul@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Prerequisite for https://github.com/kubevirt/common-templates/pull/298.
Adds the openshift python3 module to the CI builder.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/assign @ksimon1 