### PR TITLE
Add emulator thread

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -81,6 +81,10 @@ run_vm(){
   local template_name=$( oc get -n ${namespace} -f ${template_path} -o=custom-columns=NAME:.metadata.name --no-headers -n kubevirt )
   running=false
 
+  # add cpumanager=true label to all worker nodes
+  # to allow execution of tests using high performance profiles
+  oc label nodes -l node-role.kubernetes.io/worker cpumanager=true
+
   #If first try fails, it tries 2 more time to run it, before it fails whole test
   for i in `seq 1 3`; do
     error=false

--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -83,7 +83,7 @@ run_vm(){
 
   # add cpumanager=true label to all worker nodes
   # to allow execution of tests using high performance profiles
-  oc label nodes -l node-role.kubernetes.io/worker cpumanager=true
+  oc label nodes -l node-role.kubernetes.io/worker cpumanager=true --overwrite
 
   #If first try fails, it tries 2 more time to run it, before it fails whole test
   for i in `seq 1 3`; do

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -17,18 +17,18 @@
       src: rhel8.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: tiny, workload: highperformance, memsize: "1.5Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True, tablet: False, default: False}
+    - {flavor: tiny,   workload: server,          memsize: "1.5Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop,         memsize: "1.5Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: tiny,   workload: highperformance, memsize: "1.5Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: small,  workload: server,          memsize: "2Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop,         memsize: "2Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: highperformance, memsize: "2Gi",   cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop,         memsize: "4Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi",   cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi",   cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop,         memsize: "8Gi",   cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi",   cpus: 2, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
     vars:
       os: rhel8
       icon: rhel
@@ -46,18 +46,18 @@
       src: rhel7.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: tiny, workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True, tablet: False, default: False}
+    - {flavor: tiny,   workload: server,          memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop,         memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: tiny,   workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: small,  workload: server,          memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop,         memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop,         memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop,         memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
     vars:
       os: rhel7
       icon: rhel
@@ -75,14 +75,14 @@
       src: rhel6.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: tiny,   workload: server,  memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: server,  memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: server,  memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: server,  memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
     vars:
       os: rhel6
       icon: rhel
@@ -96,14 +96,14 @@
       src: centos8.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1.5Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: tiny,   workload: server,  memsize: "1.5Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop, memsize: "1.5Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: server,  memsize: "2Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop, memsize: "2Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: server,  memsize: "4Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop, memsize: "4Gi",   cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: server,  memsize: "8Gi",   cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi",   cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
     vars:
       os: centos8
       icon: centos
@@ -118,14 +118,14 @@
       src: centos7.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: tiny,   workload: server,  memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: server,  memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: server,  memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: server,  memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
     vars:
       os: centos7
       icon: centos
@@ -144,10 +144,10 @@
       src: centos6.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: server, memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: small,  workload: server, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
     vars:
       os: centos6
       icon: centos
@@ -165,18 +165,18 @@
       src: fedora.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: desktop, memsize: "1Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: tiny, workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: small, workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True, tablet: False, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True, tablet: False, default: False}
+    - {flavor: tiny,   workload: desktop,         memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: tiny,   workload: server,          memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: small,  workload: desktop,         memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: small,  workload: server,          memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: small,  workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: medium, workload: desktop,         memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
+    - {flavor: large,  workload: desktop,         memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True,  default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
     vars:
       os: fedora
       icon: fedora
@@ -190,10 +190,10 @@
       src: opensuse.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny, workload: server, memsize: "1Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: small, workload: server, memsize: "2Gi", cpus: 1, iothreads: False, tablet: False, default: True}
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: False, default: False}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: False, default: False}
+    - {flavor: tiny,   workload: server, memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: small,  workload: server, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: False, default: False}
     vars:
       os: opensuse
       icon: opensuse
@@ -209,10 +209,10 @@
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
       #minimal memory requirement for ubuntu is 2Gi, for now we don't have mechanism how to deprecate template
-    - {flavor: tiny, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: small, workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: False}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: tiny,   workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: False}
+    - {flavor: small,  workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
     vars:
       os: ubuntu
       icon: ubuntu
@@ -227,8 +227,8 @@
       src: windows2k12.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k12r2-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
     vars:
       osinfoname: win2k12r2
 
@@ -237,8 +237,8 @@
       src: windows2k16.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k16-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
     vars:
       osinfoname: win2k16
 
@@ -247,8 +247,8 @@
       src: windows2k19.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k19-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: large, workload: server, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: medium, workload: server, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: large,  workload: server, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
     vars:
       osinfoname: win2k19
 
@@ -258,6 +258,6 @@
       dest: "{{ playbook_dir }}/dist/templates/windows10-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
     - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, tablet: True, default: True}
-    - {flavor: large, workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
+    - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, tablet: True, default: False}
     vars:
       osinfoname: win10

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -98,6 +98,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
+{% if item.emulatorthread %}
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+{% endif %}
           resources:
             requests:
               memory: {{ item.memsize }}

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -96,6 +96,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
+{% if item.emulatorthread %}
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+{% endif %}
           resources:
             requests:
               memory: {{ item.memsize }}

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -96,6 +96,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
+{% if item.emulatorthread %}
+            dedicatedCpuPlacement: True
+            isolateEmulatorThread: True
+{% endif %}
           resources:
             requests:
               memory: {{ item.memsize }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR incorporates the emulator thread (isolation) feature into the templates.

**Special notes for your reviewer**:
This PR builds on top of:
- https://github.com/kubevirt/common-templates/pull/296
- https://github.com/kubevirt/common-templates/pull/297
- https://github.com/openshift/release/pull/14771
- https://github.com/openshift/release/pull/14788
- https://github.com/kubevirt/common-templates/pull/309

Also, this PR **requires** https://github.com/openshift/release/pull/14964 (in progress at the moment), which sets the appropriate compute (worker) node profile to be used in the tests with high performance settings, as discussed in prior PRs.

**Release note**:
```release-note
NONE
```
