### PR TITLE
[WIP] [Bugfix] Add storage parameters to templates

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -70,8 +70,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -150,3 +152,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -69,8 +69,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -148,3 +150,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -69,8 +69,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -148,3 +150,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -71,8 +71,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -154,3 +156,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -71,8 +71,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -150,3 +152,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -70,8 +70,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -150,3 +152,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -69,8 +69,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -152,3 +154,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -69,8 +69,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -152,3 +154,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -71,8 +71,10 @@ objects:
         name: ${NAME}
       spec:
         pvc:
+          storageClassName: ${STORAGE_CLASS}
+          volumeMode: ${VOLUME_MODE}
           accessModes:
-            - ReadWriteMany
+            - ${ACCESS_MODE}
           resources:
             requests:
               storage: 30Gi
@@ -150,3 +152,12 @@ parameters:
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
   generate: expression
   name: CLOUD_USER_PASSWORD
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -86,8 +86,10 @@ objects:
           name: ${NAME}
         spec:
           pvc:
+            storageClassName: ${STORAGE_CLASS}
+            volumeMode: ${VOLUME_MODE}
             accessModes:
-              - ReadWriteMany
+              - ${ACCESS_MODE}
             resources:
               requests:
                 storage: 60Gi
@@ -171,3 +173,12 @@ parameters:
 - name: SRC_PVC_NAMESPACE
   description: Namespace of the source PVC
   value: kubevirt-os-images
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -86,8 +86,10 @@ objects:
           name: ${NAME}
         spec:
           pvc:
+            storageClassName: ${STORAGE_CLASS}
+            volumeMode: ${VOLUME_MODE}
             accessModes:
-              - ReadWriteMany
+              - ${ACCESS_MODE}
             resources:
               requests:
                 storage: 60Gi
@@ -171,3 +173,12 @@ parameters:
 - name: SRC_PVC_NAMESPACE
   description: Namespace of the source PVC
   value: kubevirt-os-images
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -171,3 +171,12 @@ parameters:
 - name: SRC_PVC_NAMESPACE
   description: Namespace of the source PVC
   value: kubevirt-os-images
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -86,8 +86,10 @@ objects:
           name: ${NAME}
         spec:
           pvc:
+            storageClassName: ${STORAGE_CLASS}
+            volumeMode: ${VOLUME_MODE}
             accessModes:
-              - ReadWriteMany
+              - ${ACCESS_MODE}
             resources:
               requests:
                 storage: 60Gi
@@ -171,3 +173,12 @@ parameters:
 - name: SRC_PVC_NAMESPACE
   description: Namespace of the source PVC
   value: kubevirt-os-images
+- name: STORAGE_CLASS
+  description: StorageClass of the target PVC
+  required: true
+- name: VOLUME_MODE
+  description: VolumeMode of the target PVC
+  value: Block
+- name: ACCESS_MODE
+  description: AccessMode for the target PVC
+  value: ReadWriteMany


### PR DESCRIPTION
**What this PR does / why we need it**:
Add storage parameters to templates.
In the CLI flow, we can't know the name of the storage class that we need, so we have to accept it from the user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1918294

**Special notes for your reviewer**:
This is WIP, I am checking if we can improve testing by adding OCS to OCP CI

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CLI users should now provide the storageClass (required), volumeMode (optional, defaults to 'Block') and accessMode (optional, defaults to 'ReadWriteMany') for the target PVC
```
