### PR TITLE
Expand I/O threads support for high performance templates

### DIFF
--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -98,8 +98,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-{% if item.emulatorthread %}
+{% if item.iothreads or item.emulatorthread %}
             dedicatedCpuPlacement: True
+{% endif %}
+{% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
           resources:

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -120,6 +120,9 @@ objects:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: ${NAME}
+{% if item.iothreads %}
+              dedicatedIOThread: true
+{% endif %}
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -118,6 +118,9 @@ objects:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: ${NAME}
+{% if item.iothreads %}
+              dedicatedIOThread: true
+{% endif %}
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -96,8 +96,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-{% if item.emulatorthread %}
+{% if item.iothreads or item.emulatorthread %}
             dedicatedCpuPlacement: True
+{% endif %}
+{% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
           resources:

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -118,6 +118,9 @@ objects:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: ${NAME}
+{% if item.iothreads %}
+              dedicatedIOThread: true
+{% endif %}
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -96,8 +96,10 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-{% if item.emulatorthread %}
+{% if item.iothreads or item.emulatorthread %}
             dedicatedCpuPlacement: True
+{% endif %}
+{% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
           resources:


### PR DESCRIPTION
**What this PR does / why we need it**: 

This PR expands I/O threads support for high performance templates. Specifically, these changes enforce the use of dedicated CPU placement (pinning) when I/O threads are enabled. Also, it dedicates an I/O thread for the root (main) disk.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
