### PR TITLE
Bumped version of Ubuntu LTS from 18.04 to 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The table below lists the guest operating systems that are covered by the templa
 | Red Hat Enterprise Linux 6 | [rhel7](templates/rhel6.tpl.yaml) |
 | Red Hat Enterprise Linux 7 | [rhel7](templates/rhel7.tpl.yaml) |
 | Red Hat Enterprise Linux 8 | [rhel8](templates/rhel8.tpl.yaml) |
-| Ubuntu 18.04 LTS | [ubuntu](templates/ubuntu.tpl.yaml) |
+| Ubuntu 20.04 LTS | [ubuntu](templates/ubuntu.tpl.yaml) |
 | OpenSUSE Leap 15.0 | [opensuse](templates/opensuse.tpl.yaml) |
 | CentOS 6 | [centos6](templates/centos6.tpl.yaml) |
 | CentOS 7 | [centos7](templates/centos7.tpl.yaml) |

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -218,7 +218,7 @@
       icon: ubuntu
       majorrelease: ubuntu
       oslabels:
-       - ubuntu18.04
+       - ubuntu20.04
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: ubuntu
 

--- a/templates/LABELS.md
+++ b/templates/LABELS.md
@@ -19,6 +19,11 @@ identifiers](https://gitlab.com/libosinfo/osinfo-db/tree/master/data/os) from th
 
 ### Ubuntu
 
+- os.template.kubevirt.io/ubuntu20.10
+- os.template.kubevirt.io/ubuntu20.04
+- os.template.kubevirt.io/ubuntu19.10
+- os.template.kubevirt.io/ubuntu19.04
+- os.template.kubevirt.io/ubuntu18.10
 - os.template.kubevirt.io/ubuntu18.04
 - os.template.kubevirt.io/ubuntu17.10
 - os.template.kubevirt.io/ubuntu17.04


### PR DESCRIPTION
Signed-off-by: cwilkers <cwilkers@redhat.com>

**What this PR does / why we need it**:
Updates Ansible playbook to create Ubuntu templates of latest LTS, 20.04 Focal Fossa

**Special notes for your reviewer**:
Depends on PR 318 in order to properly render Ubuntu templates

**Release note**:
```release-note
Updates Ubuntu templates to 20.04 (Focal Fossa)
```
