### PR TITLE
Print templates to stdout in CI

### DIFF
--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -3,7 +3,7 @@ set -ex
 make generate
 
 #syntax check
-templates=( dist/templates/* )
+templates=`ls dist/templates/*`
 namespace="kubevirt"
 
 oc apply -f - <<EOF
@@ -15,6 +15,12 @@ EOF
 
 oc project $namespace
 
+echo "Printing templates to stdout for debugging"
+for template in $templates; do
+    cat "$template"
+done
+
+echo "Processing all templates to find syntax issues"
 for template in $templates; do
     oc process -f "$template" NAME=test SRC_PVC_NAME=test || exit 1;
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
Printing templates to stdout during testing so reviewers don't have to pull the patch and generate the templates themselves

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
