### PR TITLE
Add support for multiqueue networking for high performance Windows templates

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -227,10 +227,10 @@
       src: windows2k12.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k12r2-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: True, default: False}
-    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
-    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  tablet: True, default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: True}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
     vars:
       osinfoname: win2k12r2
 
@@ -239,10 +239,10 @@
       src: windows2k16.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k16-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: True, default: False}
-    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
-    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  tablet: True, default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: True}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
     vars:
       osinfoname: win2k16
 
@@ -251,10 +251,10 @@
       src: windows2k19.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows2k19-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: True, default: False}
-    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
-    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  tablet: True, default: False}
+    - {flavor: medium, workload: server,          memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: True}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
+    - {flavor: large,  workload: server,          memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
     vars:
       osinfoname: win2k19
 
@@ -263,9 +263,9 @@
       src: windows10.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/windows10-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: medium, workload: desktop,         memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
-    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: True, default: False}
-    - {flavor: large,  workload: desktop,         memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}
-    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  tablet: True, default: False}
+    - {flavor: medium, workload: desktop,         memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: True}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
+    - {flavor: large,  workload: desktop,         memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
     vars:
       osinfoname: win10

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -144,13 +144,20 @@ objects:
               runtime: {}
               reset: {}
           devices:
+{% if item.multiqueue %}
+            networkInterfaceMultiqueue: True
+{% endif %}
             disks:
             - disk:
                 bus: sata
               name: ${NAME}
             interfaces:
             - masquerade: {}
+{% if item.multiqueue %}
+              model: virtio
+{% else %}
               model: e1000e
+{% endif %}
               name: default
 {% if item.tablet %}
             inputs:

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -144,13 +144,20 @@ objects:
               runtime: {}
               reset: {}
           devices:
+{% if item.multiqueue %}
+            networkInterfaceMultiqueue: True
+{% endif %}
             disks:
             - disk:
                 bus: sata
               name: ${NAME}
             interfaces:
             - masquerade: {}
+{% if item.multiqueue %}
+              model: virtio
+{% else %}
               model: e1000e
+{% endif %}
               name: default
 {% if item.tablet %}
             inputs:

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -144,13 +144,20 @@ objects:
               runtime: {}
               reset: {}
           devices:
+{% if item.multiqueue %}
+            networkInterfaceMultiqueue: True
+{% endif %}
             disks:
             - disk:
                 bus: sata
               name: ${NAME}
             interfaces:
             - masquerade: {}
+{% if item.multiqueue %}
+              model: virtio
+{% else %}
               model: e1000e
+{% endif %}
               name: default
 {% if item.tablet %}
             inputs:

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -144,13 +144,20 @@ objects:
               runtime: {}
               reset: {}
           devices:
+{% if item.multiqueue %}
+            networkInterfaceMultiqueue: True
+{% endif %}
             disks:
             - disk:
                 bus: sata
               name: ${NAME}
             interfaces:
             - masquerade: {}
+{% if item.multiqueue %}
+              model: virtio
+{% else %}
               model: e1000e
+{% endif %}
               name: default
 {% if item.tablet %}
             inputs:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add support for multiqueue networking for Windows VMs. This requires two modifications:
- set `vmi.spec.domain.devices.networkInterfaceMultiqueue` appropriately; and
- set `vmi.spec.domain.devices.interfaces.model` to `virtio`.

The current proposal adds a template flag, `multiqueue` which is set to true for high performance Windows templates.
This flag is then processed in each template file to set the correct value for `devices.networkInterfaceMultiqueue` and `devices.interfaces.model`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
