### PR TITLE
roll back to previous version version of CDI

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -90,8 +90,10 @@ EOF
 fi
 
 echo "Deploying CDI"
-export CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
-            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+#export CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
+#            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+
+export CDI_VERSION="v1.29.0"
 oc apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
 oc apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
 


### PR DESCRIPTION
**What this PR does / why we need it**:
roll back to previous version version of CDI

newest version contain bug, which prevent VM to run

**Release note**:

```
NONE
```
Signed-off-by: Karel Simon <ksimon@redhat.com>