### PR TITLE
Improve tests stability

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -124,6 +124,10 @@ oc apply -n kubevirt -f kubevirt-template-validator/cluster/ocp4
 
 oc wait --for=condition=Available --timeout=${timeout}s deployment/virt-template-validator -n $namespace
 
+# add cpumanager=true label to all worker nodes
+# to allow execution of tests using high performance profiles
+oc label nodes -l node-role.kubernetes.io/worker cpumanager=true --overwrite
+
 # Apply templates
 echo "Deploying templates"
 oc apply -n $namespace  -f dist/templates


### PR DESCRIPTION
**What this PR does / why we need it**:

tests don't have to fail during VM creation
If vm is not created due to some cluster issue, test doesn't have to fail,
beacuse the retry feature can create vm again.

Command which allows cpumanager on the nodes moved to test.sh script,
because it doesn't have to run everytime vm is created.

//cc @omeryahud 

**Release note**:
```
NONE
```
Signed-off-by: Karel Simon <ksimon@redhat.com>