### PR TITLE
Update release script with new location of Version constant in SSP operator

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
           # Update the new common-templates file
           cp ../dist/${SRC_TEMPLATES_FILE} data/common-templates-bundle/${DST_TEMPLATES_FILE}
           cp ../dist/${SRC_TEMPLATES_FILE} internal/operands/common-templates/data/common-templates-bundle/${DST_TEMPLATES_FILE}
-          sed -i 's@Version.*@Version = '\"${VERSION}\"'@g' internal/operands/common-templates/resource.go
+          sed -i "s/\bVersion\s*=.*/Version = \"${VERSION}\"/g" internal/operands/common-templates/version.go
           go fmt ./...
 
           # Commit and push the changes to the update branch


### PR DESCRIPTION

**What this PR does / why we need it**:
The location of common-templates `Version` constant in the SSP operator has changed. This patch updates the release script to use the new location.

**Special notes for your reviewer**:
Do not merge until https://github.com/kubevirt/ssp-operator/pull/124 is merged.

**Release note**:
```release-note
None
```
