### PR TITLE
Explicitly set the version of the bundle when generating it for a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
           docker run \
             -v "$(pwd)":/common-templates \
             common-templates-ci \
-            /bin/bash -c "cd /common-templates && export REVISION=1 && make release"
+            /bin/bash -c "cd /common-templates && export REVISION=1 VERSION="${{ steps.get_release.outputs.tag_name }}" && make release"
 
       - name: Upload Release Asset
         id: upload-bundle-asset


### PR DESCRIPTION
**What this PR does / why we need it**:
Explicitly set the bundle version when generating it so it is correctly specified in the `template.kubevirt.io/version` label.

**Which issue(s) this PR fixes**
An issue where templates do not have the correct version in their version label

*Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
