### PR TITLE
Include full semver in release manifests

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -2,4 +2,4 @@
 if [ -z "${VERSION}" ]; then
 	VERSION=$( git describe --tags | cut -d\- -f1)
 fi
-echo ${VERSION} | sed s/^v//
+echo ${VERSION}


### PR DESCRIPTION
**What this PR does / why we need it**:
For reasons I do not know or remember the `v` from template versions is dropped when generating manifests.
I have checked with previous releases, and noticed it exists there, so I am not sure why it is dropped from this file.
I am changing this file to align with the requirement to have a full semver in our templates' version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
