### PR TITLE
Update VM API version from v1alpha3 to v1

### DIFF
--- a/templates/VALIDATION.md
+++ b/templates/VALIDATION.md
@@ -94,7 +94,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -117,7 +117,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -139,7 +139,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -202,7 +202,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -232,7 +232,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -263,7 +263,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -289,7 +289,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -314,7 +314,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -342,7 +342,7 @@ kind: Template
 metadata:
   name: windows-10
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:
@@ -365,7 +365,7 @@ kind: Template
 metadata:
   name: linux-bus-types
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     annotations:

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -39,7 +39,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -38,7 +38,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -38,7 +38,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -40,7 +40,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -40,7 +40,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -39,7 +39,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -38,7 +38,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -38,7 +38,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -43,7 +43,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -33,7 +33,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -33,7 +33,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -33,7 +33,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -33,7 +33,7 @@ metadata:
     template.kubevirt.io/default-os-variant: "true"
 {% endif %}
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     name: ${NAME}


### PR DESCRIPTION
**What this PR does / why we need it**:
Update VMs in templates to API `v1`.

**Which issue(s) this PR fixes**:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1936932

**Release note**:
```release-note
Update VM API version to v1
```
