### PR TITLE
Revert back to labeling only the worker nodes for high performace VM tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -140,9 +140,10 @@ then
 fi
 
 # add cpumanager=true label to all nodes
+# oc label nodes -l kubevirt.io/schedulable cpumanager=true --overwrite
+# add cpumanager=true label to all worker nodes
 # to allow execution of tests using high performance profiles
-# oc label nodes -l node-role.kubernetes.io/worker cpumanager=true --overwrite
-oc label nodes -l kubevirt.io/schedulable cpumanager=true --overwrite
+oc label nodes -l node-role.kubernetes.io/worker cpumanager=true --overwrite
 
 if [[ $TARGET =~ windows.* ]]; then
   ./automation/test-windows.sh $TARGET


### PR DESCRIPTION
Revert back to labeling only the worker nodes for high performace VM  tests

Signed-off-by: Shweta Padubidri <spadubid@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
