### PR TITLE
Remove any spaces when collecting the Fedora version from the Fedora repository

### DIFF
--- a/dvtemplates/fedora_new_image.sh
+++ b/dvtemplates/fedora_new_image.sh
@@ -29,7 +29,7 @@ FEDORA_REPO="quay.io/kubevirt/fedora-images"
 BASE_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/
 
 wget -qO index.html $BASE_URL || exit 1
-FEDORA_VERSION=`cat index.html | sed -e 's/.*>\(.*\)\/<.*/\1/' | sort -rn | head -n 1`
+FEDORA_VERSION=`cat index.html | sed -e 's/.*>\(.*\)\/<.*/\1/' | sort -rn | head -n 1 | tr -d ' '`
 re='^ *[0-9]+ *$'
 if ! [[ $FEDORA_VERSION =~ $re ]] ; then
     error_message 2


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes any spaces when collecting the Fedora version from the Fedora repository

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
Signed-off-by: Shweta Padubidri <spadubid@redhat.com>
