### PR TITLE
Fix os/flavor/workload annotations location

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -49,9 +49,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -82,6 +79,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -48,9 +48,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -81,6 +78,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -48,9 +48,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -81,6 +78,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -50,9 +50,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -83,6 +80,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -50,9 +50,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -83,6 +80,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -49,9 +49,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -82,6 +79,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -48,9 +48,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -81,6 +78,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -48,9 +48,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -81,6 +78,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -53,9 +53,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "{{ os }}"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -86,6 +83,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "{{ os }}"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -43,9 +43,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "windows10"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -98,6 +95,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows10"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -43,9 +43,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "windows2k12r2"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -98,6 +95,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k12r2"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -43,9 +43,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "windows2k16"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -98,6 +95,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k16"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -43,9 +43,6 @@ objects:
       vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
       app: ${NAME}
     annotations:
-      vm.kubevirt.io/os: "windows2k19"
-      vm.kubevirt.io/workload: "{{ item.workload }}"
-      vm.kubevirt.io/flavor: "{{ item.flavor }}"
       vm.kubevirt.io/validations: |
         [
           {
@@ -98,6 +95,10 @@ objects:
     running: false
     template:
       metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows2k19"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
         labels:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Moved vm.kubevirt.io/os, vm.kubevirt.io/workload,
vm.kubevirt.io/flavor annotations under
spec.template.metadata so that they will be copied
to the VMI object.

They are used as labels for the kubevirt_vmi_phase_count metric.
Annotations from the new location are copied to the VMI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
