### PR TITLE
[WIP] Rollback kubevirt version in tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -28,9 +28,9 @@ _curl() {
 		curl $@
 	fi
 }
-export KUBEVIRT_VERSION=$(_curl -L https://api.github.com/repos/kubevirt/kubevirt/releases | \
-            jq '.[] | select(.prerelease==false) | .name' | sort -V | tail -n1 | tr -d '"')
-
+#export KUBEVIRT_VERSION=$(_curl -L https://api.github.com/repos/kubevirt/kubevirt/releases | \
+#           jq '.[] | select(.prerelease==false) | .name' | sort -V | tail -n1 | tr -d '"')
+export KUBEVIRT_VERSION=v0.39.1
 ocenv="OC"
 
 if [ -z "$CLUSTERENV" ]
@@ -97,10 +97,9 @@ EOF
     fi
 fi
 echo "Deploying CDI"
-#export CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
-#            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+export CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
-export CDI_VERSION="v1.29.0"
 oc apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
 oc apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Roll back to kubevirt v0.39.1, because in v0.40.0 cpumanager label is being replaced by virt-handler.

Update CDI version

This is just temporary fix, until we find out how to set cpu manager on openshift ci
**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
