### PR TITLE
Disable testing of high performance templates.

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -47,7 +47,7 @@ sample=10
 oc wait --for=condition=Ready --timeout=${timeout}s dv/${TARGET}-datavolume-original -n $namespace
 
 sizes=("tiny" "small" "medium" "large")
-workloads=("desktop" "server" "highperformance")
+workloads=("desktop" "server")
 
 if [[ $TARGET =~ rhel6.* ]]; then
   workloads=("desktop" "server")

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -51,11 +51,11 @@ oc wait --for=condition=Ready --timeout=${timeout}s dv/${TARGET}-datavolume-orig
 oc wait --for=condition=Ready --timeout=${timeout}s pod/winrmcli -n $namespace
 
 sizes=("medium" "large")
-workloads=("server" "highperformance")
+workloads=("server")
 
 if [[ $TARGET =~ windows10.* ]]; then
   template_name="windows10"
-  workloads=("desktop" "highperformance")
+  workloads=("desktop")
 elif [[ $TARGET =~ windows2016.* ]]; then
   template_name="windows2k16"
 elif [[ $TARGET =~ windows2019.* ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable testing of high performance templates.
Due to missing cpu manager on testing nodes, we have to disable testing
of HP templates

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
