### PR TITLE
allow testing of HP templates

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -47,7 +47,7 @@ sample=10
 oc wait --for=condition=Ready --timeout=${timeout}s dv/${TARGET}-datavolume-original -n $namespace
 
 sizes=("tiny" "small" "medium" "large")
-workloads=("desktop" "server")
+workloads=("desktop" "server" "highperformance")
 
 if [[ $TARGET =~ rhel6.* ]]; then
   workloads=("desktop" "server")

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -32,7 +32,7 @@ metadata:
   namespace: kubevirt
 spec:
   containers:
-  - image: kubevirt/winrmcli
+  - image: quay.io/kubevirt/winrmcli
     command: ["/bin/sh","-c"]
     args: [ "sleep 3000"]
     imagePullPolicy: Always
@@ -51,7 +51,7 @@ oc wait --for=condition=Ready --timeout=${timeout}s dv/${TARGET}-datavolume-orig
 oc wait --for=condition=Ready --timeout=${timeout}s pod/winrmcli -n $namespace
 
 sizes=("medium" "large")
-workloads=("server")
+workloads=("server" "highperformance")
 
 if [[ $TARGET =~ windows10.* ]]; then
   template_name="windows10"


### PR DESCRIPTION
**What this PR does / why we need it**:
allow testing of HP templates
Enable CPU manager on ci nodes

The cpu manager is allowed only for templates, which have high performance variant. Other templates don't need it, because they don't have HP variant. I did it this way, because it takes about 10 minutes to enable cpu manager on nodes.

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
