### PR TITLE
Support VMs with legacy i440fx machine type

### DIFF
--- a/templates/contrib/pc/README.md
+++ b/templates/contrib/pc/README.md
@@ -1,0 +1,23 @@
+# Overview
+
+This directory provides a RHEL6 based template, to support legacy guest OS
+which require an older pc-i440fx machine type to boot.
+Clusters that were deployed using the HyperConverged Operator do not include
+support for this machine type. To allow Virtual Machines to request this
+machine type, this option should be manually added.
+
+# Update HCO
+
+It is necessary to add the relevant machine type to a list of permitted types.
+This will allow Virtual Machines to request the pc-i440fx machine type.
+
+$ oc annotate --overwrite -n openshift-cnv hco kubevirt-hyperconverged \
+  kubevirt.kubevirt.io/jsonpatch='[{"op": "add", \
+    "path": "/spec/configuration/emulatedMachines", \
+    "value": ["q35*", "pc-q35*", "pc-i440fx-rhel7.6.0"] }]'
+
+# Usage
+
+The provided template can be used to create a Virtual Machine
+
+$ oc process --local -f templates/contrib/pc/rhel6-server-large-pc-i440fx.yaml

--- a/templates/contrib/pc/rhel6-server-large-pc-i440fx.yaml
+++ b/templates/contrib/pc/rhel6-server-large-pc-i440fx.yaml
@@ -1,0 +1,155 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel6-server-large-pc-i440fx
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 6.0+ VM with i440fx machine type"
+    description: >-
+      Template for Red Hat Enterprise Linux 6 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel6.0: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.1: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.10: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.2: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.3: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.4: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.5: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.6: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.7: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.8: Red Hat Enterprise Linux 6.0 or higher
+    name.os.template.kubevirt.io/rhel6.9: Red Hat Enterprise Linux 6.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel6.0: "true"
+    os.template.kubevirt.io/rhel6.1: "true"
+    os.template.kubevirt.io/rhel6.10: "true"
+    os.template.kubevirt.io/rhel6.2: "true"
+    os.template.kubevirt.io/rhel6.3: "true"
+    os.template.kubevirt.io/rhel6.4: "true"
+    os.template.kubevirt.io/rhel6.5: "true"
+    os.template.kubevirt.io/rhel6.6: "true"
+    os.template.kubevirt.io/rhel6.7: "true"
+    os.template.kubevirt.io/rhel6.8: "true"
+    os.template.kubevirt.io/rhel6.9: "true"
+    workload.template.kubevirt.io/server-pc-i440fx: "true"
+    flavor.template.kubevirt.io/large: "true"
+objects:
+- apiVersion: kubevirt.io/v1alpha3
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel6-server-large-pc-i440fx
+      vm.kubevirt.io/template.version: "devel"
+      vm.kubevirt.io/template.revision: "1"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 536870912
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 30Gi
+        source:
+          pvc:
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel6"
+          vm.kubevirt.io/workload: "server"
+          vm.kubevirt.io/flavor: "large"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: large
+      spec:
+        domain:
+          cpu:
+            sockets: 2
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 8Gi
+          devices:
+            networkInterfaceMultiqueue: true
+            useVirtioTransitional: true
+            rng: {}
+            disks:
+            - bootOrder: 1
+              disk:
+                bus: virtio
+              name: ${NAME}
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+              model: virtio
+          machine:
+            type: pc-i440fx-rhel7.6.0
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: ${NAME}
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel6-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: SRC_PVC_NAME
+  description: Name of the PVC to clone
+  value: 'rhel6'
+- name: SRC_PVC_NAMESPACE
+  description: Namespace of the source PVC
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides an RHEL6 based meta-template, to support legacy guest OSes 
which require an older pc-i440fx machine type to boot

**Release note**:
```release-note
NONE
```
