### PR TITLE
Validate that this repository does not contain offensive language

### DIFF
--- a/.github/workflows/validate-no-offensive-lang.yml
+++ b/.github/workflows/validate-no-offensive-lang.yml
@@ -1,0 +1,15 @@
+name: validate-no-offensive-lang
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make validate-no-offensive-lang
+      run: make validate-no-offensive-lang

--- a/automation/validate-no-offensive-lang.sh
+++ b/automation/validate-no-offensive-lang.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
+ALLOW_LIST=".+[:/=]master[a-zA-Z]*/?"
+
+if git grep -inE "${OFFENSIVE_WORDS}" -- ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
+  echo "Validation failed. Found offensive language"
+  exit 1
+fi

--- a/makefile
+++ b/makefile
@@ -32,6 +32,9 @@ e2e-tests:
 unit-tests:
 	./automation/unit-tests.sh
 
+validate-no-offensive-lang:
+	./automation/validate-no-offensive-lang.sh
+
 generate: generate-templates.yaml $(METASOURCES)
 	# Just build the XML files, no need to export to tarball
 	make -C osinfo-db/ OSINFO_DB_EXPORT=echo


### PR DESCRIPTION
Add a check to the sannity test that fails if there is a usage
of offensive language in one of the files.

The script forbid the use of the words `master`, `slave`,
`blacklist` and `whitelist`

Sinse `master` is very common word as a name of default
branches or as a node name in clusters, the script allows
the usage of it if this word is part of a URL or a path.
The script does not check the file
.github/workflows/release.yaml
that may contains a lot if usage of the word `master`, which
referes to the master branch.

@ksimon1 Can you help me to trigger this check on every PR?

**Release note**:
```
NONE
```
