### PR TITLE
Add guest-agent ping based readiness probe

### DIFF
--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -86,6 +86,12 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        readinessProbe:
+          guestAgentPing: { }
+          failureThreshold: 10
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -86,6 +86,12 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        readinessProbe:
+          guestAgentPing: {}
+          failureThreshold: 10
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a readiness probe to templates with `qemu-guest-agent` based `guest-ping`

**Special notes for your reviewer**:
Based on https://github.com/kubevirt/kubevirt/pull/5946 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
