### PR TITLE
[release-v0.16] update description of rhel 9 template

### DIFF
--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     openshift.io/display-name: "Red Hat Enterprise Linux 9.0 Alpha VM"
     description: >-
+      Template for Red Hat Enterprise Linux 9 VM or newer.
+      A PVC with the RHEL disk image must be available.
       Red Hat Enterprise Linux Beta releases are made 
       available only for testing purposes. Red Hat provides 
       these Beta releases and revisions as a courtesy to 
@@ -12,14 +14,12 @@ metadata:
       Availability (GA) release, and to solicit feedback 
       from users on the Beta functionality. Red Hat does 
       not support the usage of RHEL Beta releases in 
-      production use cases. NOTE: Beta cases are 
-      handled as Severity 4. Upgrading to or from any 
-      RHEL Beta release is not an upgrade path that is 
-      supported by Red Hat. Red Hat Enterprise Linux Beta 
+      production use cases. 
+      NOTE: Beta cases are handled as Severity 4. 
+      Upgrading to or from any RHEL Beta release is not an upgrade 
+      path that is supported by Red Hat. Red Hat Enterprise Linux Beta 
       deployments cannot be directly updated to a non-beta 
       Red Hat Enterprise Linux release, or vice-versa.
-      Template for Red Hat Enterprise Linux 9 VM or newer.
-      A PVC with the RHEL disk image must be available.
     tags: "hidden,kubevirt,virtualmachine,linux,rhel"
     iconClass: "icon-{{ icon }}"
     openshift.io/provider-display-name: "KubeVirt"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is backport of https://github.com/kubevirt/common-templates/pull/371

**Release note**:
```
Update description of RHEL9 template

```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
