### PR TITLE
switch pvc to storage in datavolume spec

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -107,9 +107,7 @@ run_vm(){
   for i in `seq 1 3`; do
     error=false
     oc process ${template_option} -n $namespace -o json NAME=$vm_name SRC_PVC_NAME=$TARGET-datavolume-original SRC_PVC_NAMESPACE=kubevirt | \
-    jq 'del(.items[0].spec.dataVolumeTemplates[0].spec.pvc.accessModes) |
-    .items[0].spec.dataVolumeTemplates[0].spec.pvc+= {"accessModes": ["ReadWriteOnce"]} | 
-    .items[0].metadata.labels["vm.kubevirt.io/template.namespace"]="kubevirt"' | \
+    jq '.items[0].metadata.labels["vm.kubevirt.io/template.namespace"]="kubevirt"' | \
     oc apply -n $namespace -f -
 
     ./virtctl version

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -86,9 +86,7 @@ run_vm(){
     error=false
 
     oc process -n $namespace -o json $template_name NAME=$vm_name SRC_PVC_NAME=$TARGET-datavolume-original SRC_PVC_NAMESPACE=kubevirt | \
-    jq 'del(.items[0].spec.dataVolumeTemplates[0].spec.pvc.accessModes) |
-    .items[0].spec.dataVolumeTemplates[0].spec.pvc+= {"accessModes": ["ReadWriteOnce"]} | 
-    .items[0].metadata.labels["vm.kubevirt.io/template.namespace"]="kubevirt"' | \
+    jq '.items[0].metadata.labels["vm.kubevirt.io/template.namespace"]="kubevirt"' | \
     oc apply -n $namespace -f -
     
     # start vm

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -110,10 +110,9 @@ EOF
     fi
 fi
 echo "Deploying CDI"
-#export CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
-#            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+export CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
-export CDI_VERSION="v1.29.0"
 oc apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
 oc apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
 

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -66,9 +66,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -65,9 +65,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -65,9 +65,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -67,9 +67,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -67,9 +67,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -66,9 +66,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -65,9 +65,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -65,9 +65,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -78,9 +78,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -70,9 +70,7 @@ objects:
       metadata:
         name: ${NAME}
       spec:
-        pvc:
-          accessModes:
-            - ReadWriteMany
+        storage:
           resources:
             requests:
               storage: 30Gi

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -82,9 +82,7 @@ objects:
         metadata:
           name: ${NAME}
         spec:
-          pvc:
-            accessModes:
-              - ReadWriteMany
+          storage:
             resources:
               requests:
                 storage: 60Gi

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -82,9 +82,7 @@ objects:
         metadata:
           name: ${NAME}
         spec:
-          pvc:
-            accessModes:
-              - ReadWriteMany
+          storage:
             resources:
               requests:
                 storage: 60Gi

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -82,9 +82,7 @@ objects:
         metadata:
           name: ${NAME}
         spec:
-          pvc:
-            accessModes:
-              - ReadWriteMany
+          storage:
             resources:
               requests:
                 storage: 60Gi

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -82,9 +82,7 @@ objects:
         metadata:
           name: ${NAME}
         spec:
-          pvc:
-            accessModes:
-              - ReadWriteMany
+          storage:
             resources:
               requests:
                 storage: 60Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
 Switch pvc to storage in datavolume spec
 
The storage type is similar to pvc but allows for some additional logic to be applied. It was introduced in order to implement detection and automation of storage parameters.

**Special notes for your reviewer**:

**Release note**:
```
 Switch pvc to storage in datavolume spec
```

Signed-off-by: Karel Šimon <ksimon@redhat.com>

