### PR TITLE
Revert "change datavolume api version to v1" 

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -61,7 +61,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -60,7 +60,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -60,7 +60,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -62,7 +62,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -62,7 +62,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -61,7 +61,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -60,7 +60,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -60,7 +60,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -73,7 +73,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -65,7 +65,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-    - apiVersion: cdi.kubevirt.io/v1
+    - apiVersion: cdi.kubevirt.io/v1beta1
       kind: DataVolume
       metadata:
         name: ${NAME}

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -77,7 +77,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-      - apiVersion: cdi.kubevirt.io/v1
+      - apiVersion: cdi.kubevirt.io/v1beta1
         kind: DataVolume
         metadata:
           name: ${NAME}

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -77,7 +77,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-      - apiVersion: cdi.kubevirt.io/v1
+      - apiVersion: cdi.kubevirt.io/v1beta1
         kind: DataVolume
         metadata:
           name: ${NAME}

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -77,7 +77,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-      - apiVersion: cdi.kubevirt.io/v1
+      - apiVersion: cdi.kubevirt.io/v1beta1
         kind: DataVolume
         metadata:
           name: ${NAME}

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -77,7 +77,7 @@ objects:
         ]
   spec:
     dataVolumeTemplates:
-      - apiVersion: cdi.kubevirt.io/v1
+      - apiVersion: cdi.kubevirt.io/v1beta1
         kind: DataVolume
         metadata:
           name: ${NAME}


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert "change datavolume api version to v1" 
According to storage team the v1 is not yet out

**Which issue(s) this PR fixes** :
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1997014

**Special notes for your reviewer**:

**Release note**:

```
Revert "change datavolume api version to v1" 
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
