### PR TITLE
change RHEL9 Alpha to Beta

### DIFF
--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 Alpha VM"
+    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 Beta VM"
     description: >-
       Template for Red Hat Enterprise Linux 9 VM or newer.
       A PVC with the RHEL disk image must be available.


### PR DESCRIPTION
**What this PR does / why we need it**:
change RHEL9 Alpha to Beta
updated osinfo-db

**Release note**:
```
Change RHEL 9 Alpha to RHEL 9 Beta
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
