### PR TITLE
add patch which sets default accessMode and volumeMode

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -23,6 +23,7 @@ elif [[ $TARGET =~ refresh-image.* ]]; then
   image_url="docker://registry:5000/disk"
   # Inform CDI the local registry is insecure
   oc patch configmap cdi-insecure-registries -n cdi --type merge -p '{"data":{"mykey": "registry:5000"}}'
+  oc patch storageProfile local --type merge -p '{"spec": {"claimPropertySets":[{"accessModes": ["ReadWriteOnce"], "volumeMode": "Filesystem"}]}}'
 else
   image_url="docker://quay.io/kubevirt/common-templates:${TARGET}"
 fi;

--- a/dvtemplates/build_k8s_cluster.sh
+++ b/dvtemplates/build_k8s_cluster.sh
@@ -6,7 +6,7 @@ set -e
 cd "${PWD}/../kubevirtci"
 export KUBEVIRTCI_TAG=$(curl -L https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:"${KUBEVIRTCI_TAG}"
-export KUBEVIRT_PROVIDER=k8s-1.20
+export KUBEVIRT_PROVIDER=k8s-1.22
 export KUBEVIRT_MEMORY_SIZE=10240M
 export KUBEVIRT_PROVIDER_EXTRA_ARGS="--registry-port 5000"
 make cluster-up


### PR DESCRIPTION
**What this PR does / why we need it**:
add patch which sets default accessMode and volumeMode
bump kubernetes version

This PR updates refreshes container image automation. Previously
automation failed, due to missing informations about acessMode and
volumeMode. With this change script always sets acessMode and volumeMode
to local storageProfile.
/cc @akrejcir 

**Release note**:
```
NONE
```

Signed-off-by: Karel Šimon <ksimon@redhat.com>
