### PR TITLE
Change DataVolume source from PVC to DataSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ $ ansible-playbook generate-templates.yaml
 $ oc process --local -f dist/templates/windows10-desktop-medium.yaml
 
 $ oc process --local -f dist/templates/windows10-desktop-medium.yaml  --parameters
-NAME                DESCRIPTION                   GENERATOR           VALUE
-NAME                VM name                       expression          windows-[a-z0-9]{6}
-SRC_PVC_NAME        Name of the PVC to clone                          win10
-SRC_PVC_NAMESPACE   Namespace of the source PVC                       kubevirt-os-images
+NAME                    DESCRIPTION                       GENERATOR           VALUE
+NAME                    VM name                           expression          windows-[a-z0-9]{6}
+DATA_SOURCE_NAME        Name of the DataSource to clone                       win10
+DATA_SOURCE_NAMESPACE   Namespace of the DataSource                           kubevirt-os-images
 
 $ oc process --local -f dist/templates/windows10-desktop-medium.yaml | kubectl apply -f -
 virtualmachine.kubevirt.io/windows10-rt1ap2 created

--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -26,7 +26,7 @@ for template in $templates; do
   if [[ $template =~ .*saphana.* ]]; then
     oc process -f "$template" NAME=test TARGET_NODE_NAME=mynode || exit 1
   else
-    oc process -f "$template" NAME=test SRC_PVC_NAME=test || exit 1
+    oc process -f "$template" NAME=test DATA_SOURCE_NAME=test || exit 1
   fi
 done
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -120,11 +120,11 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: win10
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 
 objects:

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -70,10 +70,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -141,11 +141,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -69,10 +69,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -137,11 +137,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -69,10 +69,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -137,11 +137,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -71,10 +71,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -148,11 +148,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -71,10 +71,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -139,11 +139,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -70,10 +70,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -141,11 +141,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -69,10 +69,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -146,11 +146,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -69,10 +69,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -146,11 +146,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -82,10 +82,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -159,11 +159,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -74,10 +74,10 @@ objects:
           resources:
             requests:
               storage: 30Gi
-        source:
-          pvc:
-            name: ${SRC_PVC_NAME}
-            namespace: ${SRC_PVC_NAMESPACE}
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -142,11 +142,11 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}
   from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -86,10 +86,10 @@ objects:
             resources:
               requests:
                 storage: 60Gi
-          source:
-            pvc:
-              name: ${SRC_PVC_NAME}
-              namespace: ${SRC_PVC_NAMESPACE}
+          sourceRef:
+            kind: DataSource
+            name: ${DATA_SOURCE_NAME}
+            namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -178,9 +178,9 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: win10
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -86,10 +86,10 @@ objects:
             resources:
               requests:
                 storage: 60Gi
-          source:
-            pvc:
-              name: ${SRC_PVC_NAME}
-              namespace: ${SRC_PVC_NAMESPACE}
+          sourceRef:
+            kind: DataSource
+            name: ${DATA_SOURCE_NAME}
+            namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -178,9 +178,9 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: win2k12r2
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -86,10 +86,10 @@ objects:
             resources:
               requests:
                 storage: 60Gi
-          source:
-            pvc:
-              name: ${SRC_PVC_NAME}
-              namespace: ${SRC_PVC_NAMESPACE}
+          sourceRef:
+            kind: DataSource
+            name: ${DATA_SOURCE_NAME}
+            namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -178,9 +178,9 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: win2k16
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -86,10 +86,10 @@ objects:
             resources:
               requests:
                 storage: 60Gi
-          source:
-            pvc:
-              name: ${SRC_PVC_NAME}
-              namespace: ${SRC_PVC_NAMESPACE}
+          sourceRef:
+            kind: DataSource
+            name: ${DATA_SOURCE_NAME}
+            namespace: ${DATA_SOURCE_NAMESPACE}
     running: false
     template:
       metadata:
@@ -178,9 +178,9 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: SRC_PVC_NAME
-  description: Name of the PVC to clone
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
   value: win2k19
-- name: SRC_PVC_NAMESPACE
-  description: Namespace of the source PVC
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
   value: kubevirt-os-images


### PR DESCRIPTION
**What this PR does / why we need it**:
This indirection allows easier update of PVCs, because the DataSource can be updated when a new PVC is imported.

**Release note**:
```release-note
Changed DataVolume source from PVC to DataSource.
```
