### PR TITLE
fix github actions release script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,6 @@ jobs:
 
           # Update the new common-templates file
           cp ../dist/${SRC_TEMPLATES_FILE} data/common-templates-bundle/${DST_TEMPLATES_FILE}
-          cp ../dist/${SRC_TEMPLATES_FILE} internal/operands/common-templates/data/common-templates-bundle/${DST_TEMPLATES_FILE}
           sed -i "s/\bVersion\s*=.*/Version = \"${VERSION}\"/g" internal/operands/common-templates/version.go
           go fmt ./...
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix github actions release script

common-templates file were moved in ssp operator
to different folder (https://github.com/kubevirt/ssp-operator/pull/238). They no longer exists in
internal/operands/common-templates/data/common-templates-bundle/

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
