### PR TITLE
Revert parameter names back to SRC_PVC_NAME and SRC_PVC_NAMESPACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ $ oc process --local -f dist/templates/windows10-desktop-medium.yaml
 $ oc process --local -f dist/templates/windows10-desktop-medium.yaml  --parameters
 NAME                    DESCRIPTION                       GENERATOR           VALUE
 NAME                    VM name                           expression          windows-[a-z0-9]{6}
-DATA_SOURCE_NAME        Name of the DataSource to clone                       win10
-DATA_SOURCE_NAMESPACE   Namespace of the DataSource                           kubevirt-os-images
+SRC_PVC_NAME        Name of the DataSource to clone                       win10
+SRC_PVC_NAMESPACE   Namespace of the DataSource                           kubevirt-os-images
 
 $ oc process --local -f dist/templates/windows10-desktop-medium.yaml | kubectl apply -f -
 virtualmachine.kubevirt.io/windows10-rt1ap2 created

--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -148,7 +148,7 @@ run_vm() {
   #If first try fails, it tries 2 more time to run it, before it fails whole test
   for i in $(seq 1 3); do
     error=false
-    oc process ${template_option} -n $namespace -o json NAME=$vm_name DATA_SOURCE_NAME=${dv_name} DATA_SOURCE_NAMESPACE=${namespace} |
+    oc process ${template_option} -n $namespace -o json NAME=$vm_name SRC_PVC_NAME=${dv_name} SRC_PVC_NAMESPACE=${namespace} |
       jq '.items[0].metadata.labels["vm.kubevirt.io/template.namespace"]="kubevirt"' |
       oc apply -n $namespace -f -
 

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -99,7 +99,7 @@ run_vm(){
   for i in `seq 1 3`; do
     error=false
 
-    oc process -n $namespace -o json $template_name NAME=$vm_name DATA_SOURCE_NAME=${dv_name} DATA_SOURCE_NAMESPACE=${namespace} | \
+    oc process -n $namespace -o json $template_name NAME=$vm_name SRC_PVC_NAME=${dv_name} SRC_PVC_NAMESPACE=${namespace} | \
     jq '.items[0].metadata.labels["vm.kubevirt.io/template.namespace"]="kubevirt"' | \
     oc apply -n $namespace -f -
     

--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -26,7 +26,7 @@ for template in $templates; do
   if [[ $template =~ .*saphana.* ]]; then
     oc process -f "$template" NAME=test TARGET_NODE_NAME=mynode || exit 1
   else
-    oc process -f "$template" NAME=test DATA_SOURCE_NAME=test || exit 1
+    oc process -f "$template" NAME=test SRC_PVC_NAME=test || exit 1
   fi
 done
 

--- a/automation/validate-pvc-name-stability.py
+++ b/automation/validate-pvc-name-stability.py
@@ -54,19 +54,11 @@ def getParamFrom(template, paramName):
 
 
 def getDataSourceOrPvcNameFrom(template):
-    ds_name = getParamFrom(template, "DATA_SOURCE_NAME")
-    if ds_name is None:
-        return getParamFrom(template, "SRC_PVC_NAME")
-
-    return ds_name
+    return getParamFrom(template, "SRC_PVC_NAME")
 
 
 def getDataSourceOrPvcNamespaceFrom(template):
-    ds_namespace = getParamFrom(template, "DATA_SOURCE_NAMESPACE")
-    if ds_namespace is None:
-        return getParamFrom(template, "SRC_PVC_NAMESPACE")
-
-    return ds_namespace
+    return getParamFrom(template, "SRC_PVC_NAMESPACE")
 
 
 def fetchLiveTemplates():

--- a/templates/README.md
+++ b/templates/README.md
@@ -120,10 +120,10 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: win10
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -72,8 +72,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -141,10 +141,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -71,8 +71,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -137,10 +137,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/centos8.tpl.yaml
+++ b/templates/centos8.tpl.yaml
@@ -71,8 +71,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -137,10 +137,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -73,8 +73,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -148,10 +148,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -73,8 +73,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -139,10 +139,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -72,8 +72,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -141,10 +141,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -71,8 +71,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -146,10 +146,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -71,8 +71,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -146,10 +146,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -84,8 +84,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -159,10 +159,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -76,8 +76,8 @@ objects:
               storage: 30Gi
         sourceRef:
           kind: DataSource
-          name: ${DATA_SOURCE_NAME}
-          namespace: ${DATA_SOURCE_NAMESPACE}
+          name: ${SRC_PVC_NAME}
+          namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -142,10 +142,10 @@ parameters:
   from: '{{ os }}-[a-z0-9]{16}'
   generate: expression
   name: NAME
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: '{{ majorrelease }}'
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images
 - description: Randomized password for the cloud-init user {{ cloudusername }}

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -88,8 +88,8 @@ objects:
                 storage: 60Gi
           sourceRef:
             kind: DataSource
-            name: ${DATA_SOURCE_NAME}
-            namespace: ${DATA_SOURCE_NAMESPACE}
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -178,9 +178,9 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: win10
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -88,8 +88,8 @@ objects:
                 storage: 60Gi
           sourceRef:
             kind: DataSource
-            name: ${DATA_SOURCE_NAME}
-            namespace: ${DATA_SOURCE_NAMESPACE}
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -178,9 +178,9 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: win2k12r2
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -88,8 +88,8 @@ objects:
                 storage: 60Gi
           sourceRef:
             kind: DataSource
-            name: ${DATA_SOURCE_NAME}
-            namespace: ${DATA_SOURCE_NAMESPACE}
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -178,9 +178,9 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: win2k16
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -88,8 +88,8 @@ objects:
                 storage: 60Gi
           sourceRef:
             kind: DataSource
-            name: ${DATA_SOURCE_NAME}
-            namespace: ${DATA_SOURCE_NAMESPACE}
+            name: ${SRC_PVC_NAME}
+            namespace: ${SRC_PVC_NAMESPACE}
     running: false
     template:
       metadata:
@@ -178,9 +178,9 @@ parameters:
   description: VM name
   generate: expression
   from: "windows-[a-z0-9]{6}"
-- name: DATA_SOURCE_NAME
+- name: SRC_PVC_NAME
   description: Name of the DataSource to clone
   value: win2k19
-- name: DATA_SOURCE_NAMESPACE
+- name: SRC_PVC_NAMESPACE
   description: Namespace of the DataSource
   value: kubevirt-os-images


### PR DESCRIPTION
**What this PR does / why we need it**:
These names are used by the UI, the new names would break it.

**Release note**:
```release-note
None
```
