### PR TITLE
Update openshift mirror URL to working one

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -9,6 +9,6 @@ RUN mkdir -p /.ansible/tmp
 RUN chmod -R 777 /.ansible
 
 # download oc client binary
-RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.6/linux/oc.tar.gz | tar -C . -xzf -
+RUN curl https://mirror2.openshift.com/pub/openshift-v4/clients/oc/4.6/linux/oc.tar.gz | tar -C . -xzf -
 RUN chmod +x oc
 RUN mv oc /usr/bin

--- a/dvtemplates/new_cdi_image.sh
+++ b/dvtemplates/new_cdi_image.sh
@@ -104,7 +104,7 @@ docker push localhost:${port}/disk || exit "$ERROR_LOCAL_REGISTRY"
 
 # Run tests
 cd "${PWD}/../../"
-curl https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/linux/oc.tar.gz | tar -C . -xzf -
+curl https://mirror2.openshift.com/pub/openshift-v4/clients/oc/4.4/linux/oc.tar.gz | tar -C . -xzf -
 chmod +x oc
 mv oc /usr/bin
 export TARGET=refresh-image-${TARGET_OS}-test && export CLUSTERENV=K8s


### PR DESCRIPTION
**What this PR does / why we need it**:
mirror.openshift.com is retired, let's avoid referencing it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
