### PR TITLE
Change recommended disk image url 32 -> 34

### DIFF
--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -8,7 +8,7 @@ metadata:
       Template for {{ lookup('osinfo', oslabels[0]).name }} VM or newer.
       A PVC with the Fedora disk image must be available.
       Recommended disk image:
-      https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2
+      https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
     tags: "hidden,kubevirt,virtualmachine,fedora"
     iconClass: "icon-{{ icon }}"
     openshift.io/provider-display-name: "KubeVirt"


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the image download URL recommended on fedora templates from 32 -> 34 since the templates are created with Fedora 34+

**Release note**:
```
NONE
```
