### PR TITLE
highperformance windows templates now uses virtio for storage

### DIFF
--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -149,7 +149,11 @@ objects:
 {% endif %}
             disks:
             - disk:
+{% if item.workload == "highperformance" %}
+                bus: virtio
+{% else %}
                 bus: sata
+{% endif %}
               name: ${NAME}
             interfaces:
             - masquerade: {}

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -149,7 +149,11 @@ objects:
 {% endif %}
             disks:
             - disk:
+{% if item.workload == "highperformance" %}
+                bus: virtio
+{% else %}
                 bus: sata
+{% endif %}
               name: ${NAME}
             interfaces:
             - masquerade: {}

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -149,7 +149,11 @@ objects:
 {% endif %}
             disks:
             - disk:
+{% if item.workload == "highperformance" %}
+                bus: virtio
+{% else %}
                 bus: sata
+{% endif %}
               name: ${NAME}
             interfaces:
             - masquerade: {}

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -149,7 +149,11 @@ objects:
 {% endif %}
             disks:
             - disk:
+{% if item.workload == "highperformance" %}
+                bus: virtio
+{% else %}
                 bus: sata
+{% endif %}
               name: ${NAME}
             interfaces:
             - masquerade: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
highperformance windows templates now uses virtio for storage
**Which issue(s) this PR fixes** :
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2018457

**Special notes for your reviewer**:

**Release note**:
```release-note
highperformance windows templates now uses virtio for storage
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
