### PR TITLE
Adjust hana template parameter details

### DIFF
--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -24,7 +24,7 @@ done
 echo "Processing all templates to find syntax issues"
 for template in $templates; do
   if [[ $template =~ .*saphana.* ]]; then
-    oc process -f "$template" NAME=test TARGET_NODE_NAME=mynode || exit 1
+    oc process -f "$template" NAME=test WORKLOAD_NODE_LABEL_VALUE="somevalue" SRIOV_NETWORK_NAME1="default/sriov1"  SRIOV_NETWORK_NAME2="default/sriov1"  SRIOV_NETWORK_NAME3="default/sriov1"|| exit 1
   else
     oc process -f "$template" NAME=test SRC_PVC_NAME=test || exit 1
   fi

--- a/templates/rhel8.saphana.tpl.yaml
+++ b/templates/rhel8.saphana.tpl.yaml
@@ -199,7 +199,7 @@ parameters:
   - name: SRC_CONTAINERDISK
     description: Name of the source container disk to import
     displayName: Source container disk
-    value: "docker://registry.access.redhat.com/rhel8/rhel-guest-image:8.4.0"
+    value: "docker://registry.redhat.io/rhel8/rhel-guest-image:8.4.0"
   - description: Randomized password for the cloud-init user {{ cloudusername }}
     displayName: Cloud user password
     from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'

--- a/templates/rhel8.saphana.tpl.yaml
+++ b/templates/rhel8.saphana.tpl.yaml
@@ -151,6 +151,11 @@ objects:
               name: sriov-net3
           nodeSelector:
             kubevirt.io/workload: ${WORKLOAD_NODE_LABEL_VALUE}
+          tolerations:
+            - key: kubevirt.io/workload
+              operator: Equal
+              value: hana
+              effect: NoSchedule
 parameters:
   - description: Name for the new VM
     displayName: Name

--- a/templates/rhel8.saphana.tpl.yaml
+++ b/templates/rhel8.saphana.tpl.yaml
@@ -183,15 +183,15 @@ parameters:
   - description: Name of the SR-IOV network1
     displayName: SR-IOV network1
     name: SRIOV_NETWORK_NAME1
-    value: "default/sriov-net1"
+    required: true
   - description: Name of the SR-IOV network2
     displayName: SR-IOV network2
     name: SRIOV_NETWORK_NAME2
-    value: "default/sriov-net2"
+    required: true
   - description: Name of the SR-IOV network3
     displayName: SR-IOV network3
     name: SRIOV_NETWORK_NAME3
-    value: "default/sriov-net3"
+    required: true
   - description: Page size of huge pages
     displayName: Huge page size
     name: HUGEPAGES_PAGE_SIZE

--- a/templates/rhel8.saphana.tpl.yaml
+++ b/templates/rhel8.saphana.tpl.yaml
@@ -150,15 +150,15 @@ objects:
                 networkName: ${SRIOV_NETWORK_NAME3}
               name: sriov-net3
           nodeSelector:
-            kubernetes.io/hostname: ${TARGET_NODE_NAME}
+            kubevirt.io/workload: ${WORKLOAD_NODE_LABEL_VALUE}
 parameters:
   - description: Name for the new VM
     displayName: Name
     name: NAME
     required: true
-  - description: Name of the node where this VM needs to run
-    displayName: Target Node
-    name: TARGET_NODE_NAME
+  - description: Value of the node label selector key
+    displayName: "The value of the kubevirt.io/workload node selector label key. The target node needs to match this label"
+    name: WORKLOAD_NODE_LABEL_VALUE
     required: true
   - description: Amount of memory
     displayName: Memory


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves the following aspects of the hana template:
 * Use the `registry.redhat.io` registry instead of `registry.access.redhat.com`
 * Make SRIOV parameters required, since they always have to be adjusted to the environment
 * Give users the freedom to set the node selectors freely
 * Add a blanko toleration which helps scheduling the VM to exclusively dedicated nodes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Use the correct RHEL containerdisk URL, make SRIOV resource names required and make node selection more flexible
```
