### PR TITLE
Remove virtio model reference on sriov

### DIFF
--- a/templates/rhel8.saphana.tpl.yaml
+++ b/templates/rhel8.saphana.tpl.yaml
@@ -107,13 +107,10 @@ objects:
                   model: virtio
                 - name: sriov-net1
                   sriov: {}
-                  model: virtio
                 - name: sriov-net2
                   sriov: {}
-                  model: virtio
                 - name: sriov-net3
                   sriov: {}
-                  model: virtio
             machine:
               type: ""
             resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

The kubevirt validation allows passing through models on sriov devices
which it should not, and they have no effect. Removing them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
