### PR TITLE
Add annotations for containerdisks and import URLs

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -134,6 +134,10 @@
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: cloud-user
 
+  - name: Load CentOS Stream 8 image urls
+    set_fact:
+      centos8stream_image_urls: "{{ lookup('osinfo', 'centos-stream8') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+
   - name: Generate CentOS Stream 8 templates
     template:
       src: centos-stream8.tpl.yaml
@@ -155,6 +159,11 @@
        - centos-stream8
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: centos
+      image_urls: "{{ centos8stream_image_urls }}"
+
+  - name: Load CentOS Stream 9 image urls
+    set_fact:
+      centos9stream_image_urls: "{{ lookup('osinfo', 'centos-stream9') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
 
   - name: Generate CentOS Stream 9 templates
     template:
@@ -177,7 +186,11 @@
        - centos-stream9
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: centos
+      image_urls: "{{ centos9stream_image_urls }}"
 
+  - name: Load CentOS 7 image urls
+    set_fact:
+      centos7_image_urls: "{{ lookup('osinfo', 'centos7.0') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
 
   - name: Generate CentOS 7 templates
     template:
@@ -200,6 +213,7 @@
        - centos7.0
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: centos
+      image_urls: "{{ centos7_image_urls }}"
 
   - name: Load CentOS 6 versions
     set_fact:
@@ -224,7 +238,12 @@
 
   - name: Load Fedora versions
     set_fact:
-      fedora_labels: "{{ lookup('osinfo', 'distro=fedora') |select('osinfo_active') |map(attribute='short_id') |list |sort }}"
+      fedora_labels: "{{ lookup('osinfo', 'distro=fedora') |select('osinfo_active') |map(attribute='short_id') |select('match', '^fedora\\d+$') |list |sort }}"
+
+  - name: Load Fedora image urls
+    set_fact:
+      fedora_image_urls: "{{ fedora_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+    loop: "{{ fedora_labels }}"
 
   - name: Generate Fedora templates
     template:
@@ -250,10 +269,16 @@
       oslabels: "{{ fedora_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: fedora
+      image_urls: "{{ fedora_image_urls }}"
 
   - name: Load openSUSE versions
     set_fact:
       opensuse_labels: "{{ lookup('osinfo', 'distro=opensuse') |select('osinfo_active') |map(attribute='short_id') |list |sort }}"
+
+  - name: Load openSUSE image urls
+    set_fact:
+      opensuse_image_urls: "{{ opensuse_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+    loop: "{{ opensuse_labels }}"
 
   - name: Generate openSUSE templates
     template:
@@ -271,10 +296,16 @@
       oslabels: "{{ opensuse_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: opensuse
+      image_urls: "{{ opensuse_image_urls }}"
 
   - name: Load Ubuntu versions
     set_fact:
       ubuntu_labels: "{{ lookup('osinfo', 'distro=ubuntu') |select('osinfo_active') |map(attribute='short_id') |list |sort }}"
+
+  - name: Load Ubuntu image urls
+    set_fact:
+      ubuntu_image_urls: "{{ ubuntu_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+    loop: "{{ ubuntu_labels }}"
 
   - name: Generate Ubuntu templates
     template:
@@ -294,6 +325,7 @@
       oslabels: "{{ ubuntu_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: ubuntu
+      image_urls: "{{ ubuntu_image_urls }}"
 
   - name: Generate Windows server 2012 R2 templates
     template:

--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -15,6 +15,14 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      quay.io/containerdisks/centos-stream:8
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -15,6 +15,14 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      quay.io/containerdisks/centos-stream:9
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -15,6 +15,14 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      quay.io/containerdisks/centos:7-2009
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -7,8 +7,6 @@ metadata:
     description: >-
       Template for {{ lookup('osinfo', oslabels[0]).name }} VM or newer.
       A PVC with the Fedora disk image must be available.
-      Recommended disk image:
-      https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
     tags: "hidden,kubevirt,virtualmachine,fedora"
     iconClass: "icon-{{ icon }}"
     openshift.io/provider-display-name: "KubeVirt"
@@ -17,6 +15,14 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      quay.io/containerdisks/fedora:35
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -7,8 +7,6 @@ metadata:
     description: >-
       Template for {{ lookup('osinfo', oslabels[0]).name }} VM or newer.
       A PVC with the openSUSE disk image must be available.
-      Recommended disk image:
-      https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/
     tags: "hidden,kubevirt,virtualmachine,linux,opensuse"
     iconClass: "icon-{{ icon }}"
     openshift.io/provider-display-name: "KubeVirt"
@@ -17,6 +15,12 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -15,6 +15,8 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      registry.redhat.io/rhel8/rhel-guest-image
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -28,6 +28,8 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      registry.redhat.io/rhel9-beta/rhel-guest-image
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -1,5 +1,3 @@
-{% set codename = lookup('osinfo', oslabels[0]).codename %}
-{% set adjective, animal = (codename|lower).split(' ') %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -9,8 +7,6 @@ metadata:
     description: >-
       Template for Ubuntu {{ lookup('osinfo', oslabels[0]).version }} VM or newer.
       A PVC with the Ubuntu disk image must be available.
-      Recommended disk image:
-      http://cloud-images.ubuntu.com/{{ adjective }}/current/{{ adjective }}-server-cloudimg-amd64.img
     tags: "hidden,kubevirt,virtualmachine,ubuntu"
     iconClass: "icon-{{ icon }}"
     openshift.io/provider-display-name: "KubeVirt"
@@ -19,6 +15,12 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds the annotations `template.kubevirt.io/containerdisks` and
`template.kubevirt.io/images` to the common templates where appropriate.

The annotations can be used to automatically download guest images or to
display instructions for the user.

Both annotations contain lists where each element is separated by a new
line.

Image URLs are automatically obtained from the osinfo-db. Containerdisks are
static for now. (until containerdisks are added to libosinfo)

**Which issue(s) this PR fixes**

https://bugzilla.redhat.com/show_bug.cgi?id=2031155
https://bugzilla.redhat.com/show_bug.cgi?id=2038832
https://bugzilla.redhat.com/show_bug.cgi?id=2031857

**Special notes for your reviewer**:

Merge after #412 and #413, rebase first

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add template.kubevirt.io/containerdisks and template.kubevirt.io/images annotations
```
