### PR TITLE
Mark CentOS 6 template as deprecated

### DIFF
--- a/templates/LABELS.md
+++ b/templates/LABELS.md
@@ -3,6 +3,12 @@
 This file exemplarily describes the labels we will be using to select
 the workload a template is supposed to be used for.
 
+## Deprecated templates
+
+When a template is deprecated, the following annotation is applied to it: `template.kubevirt.io/deprecated: "true"`.
+
+The template itself is not removed for backward compatibility reasons.
+
 ## Operating systems
 
 The operating system labels must match the [libosinfo

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -4,6 +4,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
+    template.kubevirt.io/deprecated: "true"
     openshift.io/display-name: "CentOS 6.0+ VM"
     description: >-
       Template for CentOS 6 VM or newer.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

CentOS 6 is EOL and therefore marked as deprecated.

The deprecated templates notice, which was removed in 4e48e4e6, is
restored.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mark CentOS 6 templates as deprecated
```
