### PR TITLE
Add osinfo-db overrides for distributions without cloud images

### DIFF
--- a/osinfo-db-override/os/centos.org/centos-stream-8.xml
+++ b/osinfo-db-override/os/centos.org/centos-stream-8.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <os id="http://centos.org/centos-stream/8">
+    <image arch="x86_64" format="qcow2" cloud-init="true">
+      <url>https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220125.1.x86_64.qcow2</url>
+    </image>
+  </os>
+</libosinfo>

--- a/osinfo-db-override/os/centos.org/centos-stream-9.xml
+++ b/osinfo-db-override/os/centos.org/centos-stream-9.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <os id="http://centos.org/centos-stream/9">
+    <image arch="x86_64" format="qcow2" cloud-init="true">
+      <url>https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220211.1.x86_64.qcow2</url>
+    </image>
+  </os>
+</libosinfo>

--- a/osinfo-db-override/os/opensuse.org/opensuse-15.2.xml
+++ b/osinfo-db-override/os/opensuse.org/opensuse-15.2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <os id="http://opensuse.org/opensuse/15.2">
+    <image arch="x86_64" format="qcow2" cloud-init="true">
+      <url>https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.2/images/openSUSE-Leap-15.2.x86_64-NoCloud.qcow2</url>
+    </image>
+  </os>
+</libosinfo>

--- a/osinfo-db-override/os/opensuse.org/opensuse-15.3.xml
+++ b/osinfo-db-override/os/opensuse.org/opensuse-15.3.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <os id="http://opensuse.org/opensuse/15.3">
+    <image arch="x86_64" format="qcow2" cloud-init="true">
+      <url>https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2</url>
+    </image>
+  </os>
+</libosinfo>


### PR DESCRIPTION
**What this PR does / why we need it**:

Add osinfo-db overrides for distributions without cloud images, so
templates with image urls can be generated. 

**Special notes for your reviewer**:

Remove these overrides when cloud images are added to the distributions
in upstream osinfo-db.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
