### PR TITLE
Rename the first HD rootdisk

### DIFF
--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -110,7 +110,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk
@@ -124,7 +124,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -110,7 +110,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk
@@ -124,7 +124,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -113,7 +113,7 @@ objects:
             - bootOrder: 1
               disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk
@@ -128,7 +128,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -110,7 +110,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk
@@ -124,7 +124,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -118,7 +118,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
 {% if item.iothreads %}
               dedicatedIOThread: true
 {% endif %}
@@ -135,7 +135,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -112,7 +112,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk
@@ -126,7 +126,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -113,7 +113,7 @@ objects:
             - bootOrder: 1
               disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk
@@ -128,7 +128,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -116,7 +116,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
 {% if item.iothreads %}
               dedicatedIOThread: true
 {% endif %}
@@ -133,7 +133,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -116,7 +116,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
 {% if item.iothreads %}
               dedicatedIOThread: true
 {% endif %}
@@ -133,7 +133,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -129,7 +129,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
 {% if item.iothreads %}
               dedicatedIOThread: true
 {% endif %}
@@ -146,7 +146,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -115,7 +115,7 @@ objects:
             disks:
             - disk:
                 bus: {{ diskbus | default("virtio") }}
-              name: ${NAME}
+              name: rootdisk
             - disk:
                 bus: {{ diskbus | default("virtio") }}
               name: cloudinitdisk
@@ -129,7 +129,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -154,7 +154,7 @@ objects:
 {% else %}
                 bus: sata
 {% endif %}
-              name: ${NAME}
+              name: rootdisk
             interfaces:
             - masquerade: {}
 {% if item.multiqueue %}
@@ -173,7 +173,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         networks:
         - name: default
           pod: {}

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -154,7 +154,7 @@ objects:
 {% else %}
                 bus: sata
 {% endif %}
-              name: ${NAME}
+              name: rootdisk
             interfaces:
             - masquerade: {}
 {% if item.multiqueue %}
@@ -173,7 +173,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         networks:
         - name: default
           pod: {}

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -154,7 +154,7 @@ objects:
 {% else %}
                 bus: sata
 {% endif %}
-              name: ${NAME}
+              name: rootdisk
             interfaces:
             - masquerade: {}
 {% if item.multiqueue %}
@@ -173,7 +173,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         networks:
         - name: default
           pod: {}

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -154,7 +154,7 @@ objects:
 {% else %}
                 bus: sata
 {% endif %}
-              name: ${NAME}
+              name: rootdisk
             interfaces:
             - masquerade: {}
 {% if item.multiqueue %}
@@ -173,7 +173,7 @@ objects:
         volumes:
         - dataVolume:
             name: ${NAME}
-          name: ${NAME}
+          name: rootdisk
         networks:
         - name: default
           pod: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

The first hard disk is called by the name of the machine instead of by it's actual purpose
This creates an anomaly when printing out the names of  disk

``` bash
oc get template rhel6-server-large -n default -o json | \
     jq '.objects[0].spec.template.spec.domain.devices.disks[] | "\(.name)"'
"${NAME}"
"cloudinitdisk"
```

Expected results should be:

``` bash
oc get template rhel6-server-large -n default -o json | \
     jq '.objects[0].spec.template.spec.domain.devices.disks[] | "\(.name)"'
"rootdisk"
"cloudinitdisk"
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

