### PR TITLE
modify fedora template to start with secure boot support

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -238,7 +238,7 @@
 
   - name: Load Fedora versions
     set_fact:
-      fedora_labels: "{{ lookup('osinfo', 'distro=fedora') |select('osinfo_active') |map(attribute='short_id') |select('match', '^fedora\\d+$') |list |sort }}"
+      fedora_labels: "{{ lookup('osinfo', 'distro=fedora') |select('osinfo_active') |map(attribute='short_id') |select('match', '^fedora3[5-9]|^fedora[4-9][0-9]') |list |sort }}"
 
   - name: Load Fedora image urls
     set_fact:

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -93,6 +93,12 @@ objects:
           kubevirt.io/size: {{ item.flavor }}
       spec:
         domain:
+          features:
+            smm:
+              enabled: true
+          firmware:
+            bootloader:
+              efi: {}
 {% if item.iothreads %}
           ioThreadsPolicy: shared
 {% endif %}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
modify fedora template that support UEFI BIOS with secure boot by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
- UEFI BIOS is work with fedora35+


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
modify fedora template to have secure boot support
```
