### PR TITLE
Download oc binary from new location and readd intltool

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -11,10 +11,10 @@ RUN chmod a+w /etc/passwd
 RUN mkdir -p /.ansible/tmp && \
     chmod -R 777 /.ansible
 
-# Download oc client binary
-RUN curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/oc/latest/linux/oc.tar.gz | tar -C /usr/local/bin -xzf - oc && \
+# Download latest stable oc client binary
+RUN curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \
     chmod +x /usr/local/bin/oc
 
-# Download yq binary
+# Download latest yq binary
 RUN curl https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@
 FROM quay.io/fedora/fedora:latest
 
 # Install dependencies and tools
-RUN dnf install -y jq ansible python3-gobject python3-openshift libosinfo make git findutils expect golang
+RUN dnf install -y jq ansible python3-gobject python3-openshift libosinfo intltool make git findutils expect golang
 
 # Allow writes to /etc/passwd so a user for ansible can be added by CI commands
 RUN chmod a+w /etc/passwd


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Download the latest stable oc binary in `builder/Dockerfile` from the new
location on the mirror.

intltool was removed by accident from the dependencies. Readd it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
