### PR TITLE
Follow redirects when downloading oc and yq

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,9 +12,9 @@ RUN mkdir -p /.ansible/tmp && \
     chmod -R 777 /.ansible
 
 # Download latest stable oc client binary
-RUN curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \
     chmod +x /usr/local/bin/oc
 
 # Download latest yq binary
-RUN curl https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && \
+RUN curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Follow redirects (if there are any) when downloading oc and yq binaries
in `builder/Dockerfile`, so instead of a redirection page the actual
binaries are received.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
