### PR TITLE
Remove openSUSE osinfo-db overrides

### DIFF
--- a/osinfo-db-override/os/opensuse.org/opensuse-15.2.xml
+++ b/osinfo-db-override/os/opensuse.org/opensuse-15.2.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<libosinfo version="0.0.1">
-  <os id="http://opensuse.org/opensuse/15.2">
-    <image arch="x86_64" format="qcow2" cloud-init="true">
-      <url>https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.2/images/openSUSE-Leap-15.2.x86_64-NoCloud.qcow2</url>
-    </image>
-  </os>
-</libosinfo>

--- a/osinfo-db-override/os/opensuse.org/opensuse-15.3.xml
+++ b/osinfo-db-override/os/opensuse.org/opensuse-15.3.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<libosinfo version="0.0.1">
-  <os id="http://opensuse.org/opensuse/15.3">
-    <image arch="x86_64" format="qcow2" cloud-init="true">
-      <url>https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.3/images/openSUSE-Leap-15.3.x86_64-NoCloud.qcow2</url>
-    </image>
-  </os>
-</libosinfo>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The links added by the overrides are now included in upstream osinfo-db.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
