### PR TITLE
Add windows 11 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The table below lists the guest operating systems that are covered by the templa
 | Microsoft Windows Server 2016 | [windows2k16](templates/windows2k16.tpl.yaml) |
 | Microsoft Windows Server 2019 | [windows2k19](templates/windows2k19.tpl.yaml) |
 | Microsoft Windows 10 | [windows10](templates/windows10.tpl.yaml) |
+| Microsoft Windows 11 | [windows11](templates/windows11.tpl.yaml) |
 | Fedora | [fedora](templates/fedora.tpl.yaml) |
 | Red Hat Enterprise Linux 6 | [rhel6](templates/rhel6.tpl.yaml) |
 | Red Hat Enterprise Linux 7 | [rhel7](templates/rhel7.tpl.yaml) |

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -4,6 +4,7 @@ set -ex
 
 namespace="kubevirt"
 template_name="windows2k12r2"
+username="Administrator"
 
 dv_name="${TARGET}-datavolume-original"
 
@@ -70,6 +71,10 @@ workloads=("server" "highperformance")
 if [[ $TARGET =~ windows10.* ]]; then
   template_name="windows10"
   workloads=("desktop")
+elif [[ $TARGET =~ windows11.* ]]; then
+  template_name="windows11"
+  username="Administrator11"
+  workloads=("desktop")
 elif [[ $TARGET =~ windows2016.* ]]; then
   template_name="windows2k16"
 elif [[ $TARGET =~ windows2019.* ]]; then
@@ -78,7 +83,6 @@ fi
 
 delete_vm(){
   vm_name=$1
-  local template_name=$2
   set +e
   #stop vm
   ./virtctl stop $vm_name -n $namespace
@@ -113,7 +117,7 @@ run_vm(){
 
     current_time=0
     # run ipconfig /all command on windows vm
-    while [[ $(oc exec -n $namespace -i winrmcli -- ./usr/bin/winrm-cli -hostname $ipAddressVMI -port 5985 -username "Administrator" -password "Heslo123" "ipconfig /all" | grep "IPv4 Address" | wc -l ) -eq 0 ]] ; do 
+    while [[ $(oc exec -n $namespace -i winrmcli -- ./usr/bin/winrm-cli -hostname $ipAddressVMI -port 5985 -username $username -password "Heslo123" "ipconfig /all" | grep "IPv4 Address" | wc -l ) -eq 0 ]] ; do
       # VM can be stopped during test and recreated. That will change IP, so to be sure, get IP at every iteration
       ipAddressVMI=$(oc get vmi $vm_name -o json -n $namespace| jq -r '.status.interfaces[0].ipAddress')
       current_time=$((current_time + sample))

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -360,3 +360,15 @@
     - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
     vars:
       osinfoname: win10
+
+  - name: Generate Windows 11 templates
+    template:
+      src: windows11.tpl.yaml
+      dest: "{{ playbook_dir }}/dist/templates/windows11-{{ item.workload }}-{{ item.flavor }}.yaml"
+    with_items:
+    - {flavor: medium, workload: desktop,         memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: True}
+    - {flavor: medium, workload: highperformance, memsize: "4Gi", cpus: 1, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
+    - {flavor: large,  workload: desktop,         memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, multiqueue: False, tablet: True, default: False}
+    - {flavor: large,  workload: highperformance, memsize: "8Gi", cpus: 2, iothreads: True,  emulatorthread: True,  multiqueue: True,  tablet: True, default: False}
+    vars:
+      osinfoname: win11

--- a/osinfo-db-override/os/microsoft.com/win-11.xml
+++ b/osinfo-db-override/os/microsoft.com/win-11.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <!-- Licensed under the GNU General Public License version 2 or later.
+     See http://www.gnu.org/licenses/ for a copy of the license text -->
+  <os id="http://microsoft.com/win/11">
+    <short-id>win11</short-id>
+    <name>Microsoft Windows 11</name>
+    <version>11.0</version>
+    <vendor>Microsoft Corporation</vendor>
+    <vendor xml:lang="ko">Microsoft Corporation</vendor>
+    <vendor xml:lang="uk">&#x41A;&#x43E;&#x440;&#x43F;&#x43E;&#x440;&#x430;&#x446;&#x456;&#x44F; Microsoft</vendor>
+    <vendor xml:lang="tr">Microsoft Corporation</vendor>
+    <vendor xml:lang="pt_BR">Microsoft Corporation</vendor>
+    <vendor xml:lang="pl">Microsoft Corporation</vendor>
+    <vendor xml:lang="ja">Microsoft Corporation</vendor>
+    <vendor xml:lang="it">Microsoft Corporation</vendor>
+    <vendor xml:lang="id">Microsoft Corporation</vendor>
+    <vendor xml:lang="fr">Microsoft Corporation</vendor>
+    <vendor xml:lang="es">Microsoft Corporation</vendor>
+    <vendor xml:lang="de">Microsoft Corporation</vendor>
+    <vendor xml:lang="ca">Microsoft Corporation</vendor>
+    <family>winnt</family>
+    <distro>win</distro>
+    <derives-from id="http://microsoft.com/win/10"/>
+    <upgrades id="http://microsoft.com/win/10"/>
+    <release-date>2021-10-05</release-date>
+    <firmware arch="x86_64" type="efi"/>
+    <firmware arch="x86_64" type="bios" supported="false"/>
+    <resources arch="x86_64">
+      <minimum>
+        <cpu>1000000000</cpu>
+        <n-cpus>2</n-cpus>
+        <ram>4294967296</ram>
+        <storage>68719476736</storage>
+      </minimum>
+    </resources>
+  </os>
+</libosinfo>

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -56,7 +56,7 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
             "values": ["virtio"],
             "justWarning": true
           }, {

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -1,0 +1,202 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: windows11-{{ item.workload }}-{{ item.flavor }}
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 11 VM"
+    description: >-
+      Template for Microsoft Windows 11 VM.
+      A PVC with the Windows disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,windows"
+    iconClass: "icon-windows"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    defaults.template.kubevirt.io/network: default
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/win11: {{ lookup('osinfo', osinfoname).name }}
+  labels:
+    os.template.kubevirt.io/win11: "true"
+    workload.template.kubevirt.io/{{ item.workload }}: "true"
+    flavor.template.kubevirt.io/{{ item.flavor }}: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+{% if item.default %}
+    template.kubevirt.io/default-os-variant: "true"
+{% endif %}
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: windows11-{{ item.workload }}-{{ item.flavor }}
+      vm.kubevirt.io/template.version: "{{ lookup('env', 'VERSION') | default('devel', true) }}"
+      vm.kubevirt.io/template.revision: "{{ lookup('env', 'REVISION') | default(1, true) }}"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64.ram"] }}
+          }, {
+            "name": "windows-virtio-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio"],
+            "justWarning": true
+          }, {
+            "name": "windows-disk-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
+            "rule": "enum",
+            "message": "disk bus has to be either virtio or sata or scsi",
+            "values": ["virtio", "sata", "scsi"]
+          }, {
+            "name": "windows-cd-bus",
+            "path": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "valid": "jsonpath::.spec.domain.devices.disks[*].cdrom.bus",
+            "rule": "enum",
+            "message": "cd bus has to be sata",
+            "values": ["sata"]
+          }, {
+            "name": "minimal-required-cores",
+            "path": "jsonpath::.spec.domain.cpu.cores",
+            "rule": "integer",
+            "message": "This VM requires more cores.",
+            "min": 2
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+      - apiVersion: cdi.kubevirt.io/v1beta1
+        kind: DataVolume
+        metadata:
+          name: ${NAME}
+        spec:
+          storage:
+            resources:
+              requests:
+                storage: 64Gi
+          sourceRef:
+            kind: DataSource
+            name: ${DATA_SOURCE_NAME}
+            namespace: ${DATA_SOURCE_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "windows11"
+          vm.kubevirt.io/workload: "{{ item.workload }}"
+          vm.kubevirt.io/flavor: "{{ item.flavor }}"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: {{ item.flavor }}
+      spec:
+        domain:
+          clock:
+            utc: {}
+            timer:
+              hpet:
+                present: false
+              pit:
+                tickPolicy: delay
+              rtc:
+                tickPolicy: catchup
+              hyperv: {}
+          cpu:
+            sockets: {{ item.cpus }}
+            cores: 2
+            threads: 1
+{% if item.iothreads or item.emulatorthread %}
+            dedicatedCpuPlacement: True
+{% endif %}
+{% if item.emulatorthread %}
+            isolateEmulatorThread: True
+{% endif %}
+          resources:
+            requests:
+              memory: {{ item.memsize }}
+          features:
+            acpi: {}
+            apic: {}
+            smm: {}
+            hyperv:
+              relaxed: {}
+              vapic: {}
+              vpindex: {}
+              spinlocks:
+                spinlocks: 8191
+              synic: {}
+              synictimer:
+                direct: {}
+              tlbflush: {}
+              frequencies: {}
+              reenlightenment: {}
+              ipi: {}
+              runtime: {}
+              reset: {}
+          firmware:
+            bootloader:
+              efi:
+                secureBoot: true
+          devices:
+{% if item.multiqueue %}
+            networkInterfaceMultiqueue: True
+{% endif %}
+            disks:
+            - disk:
+{% if item.workload == "highperformance" %}
+                bus: virtio
+{% else %}
+                bus: sata
+{% endif %}
+              name: rootdisk
+            interfaces:
+            - masquerade: {}
+{% if item.multiqueue %}
+              model: virtio
+{% else %}
+              model: e1000e
+{% endif %}
+              name: default
+{% if item.tablet %}
+            inputs:
+              - type: tablet
+                bus: usb
+                name: tablet
+{% endif %}
+            tpm: {}
+        terminationGracePeriodSeconds: 3600
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: rootdisk
+        networks:
+        - name: default
+          pod: {}
+parameters:
+- name: NAME
+  description: VM name
+  generate: expression
+  from: "windows-[a-z0-9]{6}"
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
+  value: win11
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
+  value: kubevirt-os-images

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -56,7 +56,7 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
             "values": ["virtio"],
             "justWarning": true
           }, {

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -56,7 +56,7 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
             "values": ["virtio"],
             "justWarning": true
           }, {

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -56,7 +56,7 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
             "values": ["virtio"],
             "justWarning": true
           }, {

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -56,7 +56,7 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virto disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
             "values": ["virtio"],
             "justWarning": true
           }, {


### PR DESCRIPTION
Signed-off-by: fossedihelm <ffossemo@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add windows 11 template. Windows 11 information currently is not present in osinfo-db (there is an open PR [https://gitlab.com/libosinfo/osinfo-db/-/merge_requests/362](https://gitlab.com/libosinfo/osinfo-db/-/merge_requests/362)); fot this reason has been added an entry fot it in [https://github.com/kubevirt/common-templates/tree/master/osinfo-db-override/os](https://github.com/kubevirt/common-templates/tree/master/osinfo-db-override/os)
This PR requires [https://github.com/kubevirt/kubevirt/pull/7103](https://github.com/kubevirt/kubevirt/pull/7103) since the latter introduce the TPM 2.0 support, required by Windows 11

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add windows 11 template
```
