### PR TITLE
Have RHEL 9 template use UEFI by default

### DIFF
--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -141,6 +141,12 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+          features:
+            smm:
+              enabled: true
+          firmware:
+            bootloader:
+              efi: {}
         terminationGracePeriodSeconds: 180
         networks:
         - name: default


### PR DESCRIPTION
SecureBoot will be enabled to follow KubeVirt's
default setting.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable UEFI by default for the RHEL 9 template
```
