### PR TITLE
Change docker commands into podman

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,8 @@ jobs:
         run: |
           git submodule init
           git submodule update
-          docker build -t common-templates-ci ./builder/
-          docker run \
+          podman build -t common-templates-ci ./builder/
+          podman run \
             -v "$(pwd)":/common-templates \
             common-templates-ci \
             /bin/bash -c "cd /common-templates && export REVISION=1 VERSION="${{ steps.get_release.outputs.tag_name }}" && make release"

--- a/dvtemplates/build_k8s_cluster.sh
+++ b/dvtemplates/build_k8s_cluster.sh
@@ -13,7 +13,7 @@ make cluster-up
 export KUBECONFIG=$(cluster-up/kubeconfig.sh)
 
 # Login details for the Quay Registry
-cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
 
 # Execute the script to build a CentOS/Fedora Container Disk Image
 cd "${PWD}/../common-templates/dvtemplates/"

--- a/dvtemplates/new_cdi_image.sh
+++ b/dvtemplates/new_cdi_image.sh
@@ -72,8 +72,8 @@ fi
 echo "Latest ${TARGET_OS} version is : ${OS_VERSION}"
 
 # Fetch the old image
-docker pull -a $OS_REPO
-OS_OLD_VERSION=$(docker images $OS_REPO --format "{{json .}}" | jq 'select(.Tag|test('\"$re\"')) | .Tag' | sort -rn | head -n 1 | tr -d '"')
+podman pull -a $OS_REPO
+OS_OLD_VERSION=$(podman images $OS_REPO --format "{{json .}}" | jq 'select(.Tag|test('\"$re\"')) | .Tag' | sort -rn | head -n 1 | tr -d '"')
 echo "${TARGET_OS} version in the Image Registry is : ${OS_OLD_VERSION}"
 
 if [ -z "${OS_OLD_VERSION}" ]; then
@@ -99,8 +99,8 @@ wget -q --show-progress $URL || exit "$ERROR_IMAGE_URL_UNREACHABLE"
 echo -e "Successfully downloaded new ${TARGET_OS} version: ${OS_VERSION} image"
 
 # Build and push the qcow2 Image in a Container to a local registry for testing
-docker build . --label $IMG_LABEL -t localhost:${port}/disk
-docker push localhost:${port}/disk || exit "$ERROR_LOCAL_REGISTRY"
+podman build . --label $IMG_LABEL -t localhost:${port}/disk
+podman push localhost:${port}/disk || exit "$ERROR_LOCAL_REGISTRY"
 
 # Run tests
 cd "${PWD}/../../"
@@ -112,6 +112,6 @@ export TARGET=refresh-image-${TARGET_OS}-test && export CLUSTERENV=K8s
 #
 # If testing passes push the new image to the final Image registry
 for tag in {$OS_VERSION,latest}; do
-    docker tag localhost:${port}/disk ${OS_REPO}:${tag}
-    docker push ${OS_REPO}:${tag} || exit "$ERROR_QUAY_REGISTRY"
+    podman tag localhost:${port}/disk ${OS_REPO}:${tag}
+    podman push ${OS_REPO}:${tag} || exit "$ERROR_QUAY_REGISTRY"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:

Change docker commands into podman

**Release note**:
```
Removes all docker references and replaces them with podman.
```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>
