### PR TITLE
Add containerdisks annotation to Ubuntu template

### DIFF
--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -15,6 +15,10 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      quay.io/containerdisks/ubuntu:18.04
+      quay.io/containerdisks/ubuntu:20.04
+      quay.io/containerdisks/ubuntu:22.04
 {% if image_urls | length > 0 %}
     template.kubevirt.io/images: |
 {% for url in image_urls %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds the containerdisks annotation to the Ubuntu template.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add containerdisks annotation to Ubuntu template
```
