### PR TITLE
Remove version information from fedora display name

### DIFF
--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
-    openshift.io/display-name: "{{ lookup('osinfo', oslabels[0]).name }}+ VM"
+    openshift.io/display-name: "Fedora VM"
     description: >-
       Template for {{ lookup('osinfo', oslabels[0]).name }} VM or newer.
       A PVC with the Fedora disk image must be available.


### PR DESCRIPTION
Because Fedora increases it's major version quickly, an old
version in the display name might confuse the user.
The minimal required Fedora version is still mentioned in the
description.

Signed-off-by: Dominik Holler <dholler@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Remove version information from fedora display name
```
