### PR TITLE
bump fedora containerdisk to 36

### DIFF
--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -16,7 +16,7 @@ metadata:
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
     template.kubevirt.io/containerdisks: |
-      quay.io/containerdisks/fedora:35
+      quay.io/containerdisks/fedora:36
 {% if image_urls | length > 0 %}
     template.kubevirt.io/images: |
 {% for url in image_urls %}


### PR DESCRIPTION
**What this PR does / why we need it**:
bump fedora containerdisk to 36

**Release note**:
```
bump fedora containerdisk to 36
```
