### PR TITLE
Use latest fedora containerdisk

### DIFF
--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -16,7 +16,7 @@ metadata:
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
     template.kubevirt.io/containerdisks: |
-      quay.io/containerdisks/fedora:36
+      quay.io/containerdisks/fedora:latest
 {% if image_urls | length > 0 %}
     template.kubevirt.io/images: |
 {% for url in image_urls %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This ensures that the latest available Fedora version is always used.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use latest fedora containerdisk
```
