### PR TITLE
Add image URLs to RHEL templates

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -12,6 +12,11 @@
     set_fact:
       rhel9_labels: "{{ lookup('osinfo', 'distro=rhel') |map(attribute='short_id') |select('match', '^rhel9\\.') |list |sort }}"
 
+  - name: Load RHEL 9 image urls
+    set_fact:
+      rhel9_image_urls: "{{ rhel9_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+    loop: "{{ rhel9_labels }}"
+
   - name: Generate RHEL 9 templates
     template:
       src: rhel9.tpl.yaml
@@ -36,10 +41,16 @@
       oslabels: "{{ rhel9_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: cloud-user
+      image_urls: "{{ rhel9_image_urls }}"
 
   - name: Load RHEL 8 versions
     set_fact:
       rhel8_labels: "{{ lookup('osinfo', 'distro=rhel') |map(attribute='short_id') |select('match', '^rhel8\\.') |list |sort }}"
+
+  - name: Load RHEL 8 image urls
+    set_fact:
+      rhel8_image_urls: "{{ rhel8_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+    loop: "{{ rhel8_labels }}"
 
   - name: Generate RHEL 8 templates
     template:
@@ -65,10 +76,16 @@
       oslabels: "{{ rhel8_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: cloud-user
+      image_urls: "{{ rhel8_image_urls }}"
 
   - name: Load RHEL 7 versions
     set_fact:
       rhel7_labels: "{{ lookup('osinfo', 'distro=rhel') |map(attribute='short_id') |select('match', '^rhel7\\.') |list |sort }}"
+
+  - name: Load RHEL 7 image urls
+    set_fact:
+      rhel7_image_urls: "{{ rhel7_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+    loop: "{{ rhel7_labels }}"
 
   - name: Generate RHEL 7 templates
     template:
@@ -94,10 +111,16 @@
       oslabels: "{{ rhel7_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: cloud-user
+      image_urls: "{{ rhel7_image_urls }}"
 
   - name: Load RHEL 6 versions
     set_fact:
       rhel6_labels: "{{ lookup('osinfo', 'distro=rhel') |map(attribute='short_id') |select('match', '^rhel6\\.') |list |sort }}"
+
+  - name: Load RHEL 6 image urls
+    set_fact:
+      rhel6_image_urls: "{{ rhel6_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+    loop: "{{ rhel6_labels }}"
 
   - name: Generate RHEL 6 templates
     template:
@@ -119,6 +142,7 @@
       oslabels: "{{ rhel6_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: cloud-user
+      image_urls: "{{ rhel6_image_urls }}"
 
   - name: Load CentOS Stream 8 image urls
     set_fact:

--- a/osinfo-db-override/os/redhat.com/rhel-6.10.xml
+++ b/osinfo-db-override/os/redhat.com/rhel-6.10.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <os id="http://redhat.com/rhel/6.10">
+    <image arch="x86_64" format="qcow2" cloud-init="true">
+      <url>https://access.redhat.com/downloads/content/69/ver=/rhel---6/6.10/x86_64/product-software</url>
+    </image>
+  </os>
+</libosinfo>

--- a/osinfo-db-override/os/redhat.com/rhel-7.9.xml
+++ b/osinfo-db-override/os/redhat.com/rhel-7.9.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <os id="http://redhat.com/rhel/7.9">
+    <image arch="x86_64" format="qcow2" cloud-init="true">
+      <url>https://access.redhat.com/downloads/content/69/ver=/rhel---7/7.9/x86_64/product-software</url>
+    </image>
+  </os>
+</libosinfo>

--- a/osinfo-db-override/os/redhat.com/rhel-8.6.xml
+++ b/osinfo-db-override/os/redhat.com/rhel-8.6.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <os id="http://redhat.com/rhel/8.6">
+    <image arch="x86_64" format="qcow2" cloud-init="true">
+      <url>https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.6/x86_64/product-software</url>
+    </image>
+  </os>
+</libosinfo>

--- a/osinfo-db-override/os/redhat.com/rhel-9.0.xml
+++ b/osinfo-db-override/os/redhat.com/rhel-9.0.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<libosinfo version="0.0.1">
+  <os id="http://redhat.com/rhel/9.0">
+    <image arch="x86_64" format="qcow2" cloud-init="true">
+      <url>https://access.redhat.com/downloads/content/479/ver=/rhel---9/9.0/x86_64/product-software</url>
+    </image>
+  </os>
+</libosinfo>

--- a/templates/rhel6.tpl.yaml
+++ b/templates/rhel6.tpl.yaml
@@ -16,6 +16,12 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -15,6 +15,12 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -17,6 +17,12 @@ metadata:
     defaults.template.kubevirt.io/disk: rootdisk
     template.kubevirt.io/containerdisks: |
       registry.redhat.io/rhel8/rhel-guest-image
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -17,6 +17,12 @@ metadata:
     defaults.template.kubevirt.io/disk: rootdisk
     template.kubevirt.io/containerdisks: |
       registry.redhat.io/rhel9/rhel-guest-image
+{% if image_urls | length > 0 %}
+    template.kubevirt.io/images: |
+{% for url in image_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds osinfo-db overrides to provide links to the RHEL download
pages where KVM Guest Image links can be acquired.

See here for example:
![rheldownload](https://user-images.githubusercontent.com/441757/174564316-d19005bc-aaf5-47d0-aee8-60a4975489a4.png)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add image URLs to RHEL templates
```


