### PR TITLE
Use containerdisk urls provided by osinfo-db

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -144,8 +144,9 @@
       cloudusername: cloud-user
       image_urls: "{{ rhel6_image_urls }}"
 
-  - name: Load CentOS Stream 8 image urls
+  - name: Load CentOS Stream 8 containerdisk and image urls
     set_fact:
+      centos8stream_containerdisk_urls: "{{ lookup('osinfo', 'centos-stream8') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'eq', 'containerdisk') |map(attribute='url') |map('replace', 'docker://', '') |list }}"
       centos8stream_image_urls: "{{ lookup('osinfo', 'centos-stream8') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
 
   - name: Generate CentOS Stream 8 templates
@@ -169,10 +170,12 @@
        - centos-stream8
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: centos
+      containerdisk_urls: "{{ centos8stream_containerdisk_urls }}"
       image_urls: "{{ centos8stream_image_urls }}"
 
-  - name: Load CentOS Stream 9 image urls
+  - name: Load CentOS Stream 9 containerdisk and image urls
     set_fact:
+      centos9stream_containerdisk_urls: "{{ lookup('osinfo', 'centos-stream9') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'eq', 'containerdisk') |map(attribute='url') |map('replace', 'docker://', '') |list }}"
       centos9stream_image_urls: "{{ lookup('osinfo', 'centos-stream9') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
 
   - name: Generate CentOS Stream 9 templates
@@ -196,10 +199,12 @@
        - centos-stream9
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: centos
+      containerdisk_urls: "{{ centos9stream_containerdisk_urls }}"
       image_urls: "{{ centos9stream_image_urls }}"
 
-  - name: Load CentOS 7 image urls
+  - name: Load CentOS 7 containerdisk and image urls
     set_fact:
+      centos7_containerdisk_urls: "{{ lookup('osinfo', 'centos7.0') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'eq', 'containerdisk') |map(attribute='url') |map('replace', 'docker://', '') |list }}"
       centos7_image_urls: "{{ lookup('osinfo', 'centos7.0') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
 
   - name: Generate CentOS 7 templates
@@ -223,6 +228,7 @@
        - centos7.0
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: centos
+      containerdisk_urls: "{{ centos7_containerdisk_urls }}"
       image_urls: "{{ centos7_image_urls }}"
 
   - name: Load CentOS 6 versions
@@ -250,8 +256,9 @@
     set_fact:
       fedora_labels: "{{ lookup('osinfo', 'distro=fedora') |select('osinfo_active') |map(attribute='short_id') |select('match', '^fedora3[5-9]|^fedora[4-9][0-9]') |list |sort }}"
 
-  - name: Load Fedora image urls
+  - name: Load Fedora containerdisk and image urls
     set_fact:
+      fedora_containerdisk_urls: "{{ fedora_containerdisk_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'eq', 'containerdisk') |map(attribute='url') |map('replace', 'docker://', '') |list }}"
       fedora_image_urls: "{{ fedora_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
     loop: "{{ fedora_labels }}"
 
@@ -279,6 +286,7 @@
       oslabels: "{{ fedora_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: fedora
+      containerdisk_urls: "{{ fedora_containerdisk_urls }}"
       image_urls: "{{ fedora_image_urls }}"
 
   - name: Load openSUSE versions
@@ -312,8 +320,9 @@
     set_fact:
       ubuntu_labels: "{{ lookup('osinfo', 'distro=ubuntu') |select('osinfo_active') |map(attribute='short_id') |list |sort }}"
 
-  - name: Load Ubuntu image urls
+  - name: Load Ubuntu containerdisk and image urls
     set_fact:
+      ubuntu_containerdisk_urls: "{{ ubuntu_containerdisk_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'eq', 'containerdisk') |map(attribute='url') |map('replace', 'docker://', '') |list }}"
       ubuntu_image_urls: "{{ ubuntu_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
     loop: "{{ ubuntu_labels }}"
 
@@ -335,6 +344,7 @@
       oslabels: "{{ ubuntu_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: ubuntu
+      containerdisk_urls: "{{ ubuntu_containerdisk_urls }}"
       image_urls: "{{ ubuntu_image_urls }}"
 
   - name: Generate Windows server 2012 R2 templates

--- a/osinfo-db-override/os/centos.org/centos-stream-8.xml
+++ b/osinfo-db-override/os/centos.org/centos-stream-8.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <libosinfo version="0.0.1">
   <os id="http://centos.org/centos-stream/8">
+    <image arch="x86_64" format="containerdisk" cloud-init="true">
+      <url>docker://quay.io/containerdisks/centos-stream:8</url>
+    </image>
     <image arch="x86_64" format="qcow2" cloud-init="true">
-      <url>https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220125.1.x86_64.qcow2</url>
+      <url>https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220913.0.x86_64.qcow2</url>
     </image>
   </os>
 </libosinfo>

--- a/osinfo-db-override/os/centos.org/centos-stream-9.xml
+++ b/osinfo-db-override/os/centos.org/centos-stream-9.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <libosinfo version="0.0.1">
   <os id="http://centos.org/centos-stream/9">
+    <image arch="x86_64" format="containerdisk" cloud-init="true">
+      <url>docker://quay.io/containerdisks/centos-stream:9</url>
+    </image>
     <image arch="x86_64" format="qcow2" cloud-init="true">
-      <url>https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220211.1.x86_64.qcow2</url>
+      <url>https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220914.0.x86_64.qcow2</url>
     </image>
   </os>
 </libosinfo>

--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -15,8 +15,12 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+{% if containerdisk_urls | length > 0 %}
     template.kubevirt.io/containerdisks: |
-      quay.io/containerdisks/centos-stream:8
+{% for url in containerdisk_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
 {% if image_urls | length > 0 %}
     template.kubevirt.io/images: |
 {% for url in image_urls %}

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -15,8 +15,12 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+{% if containerdisk_urls | length > 0 %}
     template.kubevirt.io/containerdisks: |
-      quay.io/containerdisks/centos-stream:9
+{% for url in containerdisk_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
 {% if image_urls | length > 0 %}
     template.kubevirt.io/images: |
 {% for url in image_urls %}

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -15,8 +15,12 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+{% if containerdisk_urls | length > 0 %}
     template.kubevirt.io/containerdisks: |
-      quay.io/containerdisks/centos:7-2009
+{% for url in containerdisk_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
 {% if image_urls | length > 0 %}
     template.kubevirt.io/images: |
 {% for url in image_urls %}

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -17,6 +17,9 @@ metadata:
     defaults.template.kubevirt.io/disk: rootdisk
     template.kubevirt.io/containerdisks: |
       quay.io/containerdisks/fedora:latest
+{% for url in containerdisk_urls %}
+      {{ url }}
+{% endfor %}
 {% if image_urls | length > 0 %}
     template.kubevirt.io/images: |
 {% for url in image_urls %}

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -15,10 +15,12 @@ metadata:
     template.openshift.io/bindable: "false"
     template.kubevirt.io/version: v1alpha1
     defaults.template.kubevirt.io/disk: rootdisk
+{% if containerdisk_urls | length > 0 %}
     template.kubevirt.io/containerdisks: |
-      quay.io/containerdisks/ubuntu:18.04
-      quay.io/containerdisks/ubuntu:20.04
-      quay.io/containerdisks/ubuntu:22.04
+{% for url in containerdisk_urls %}
+      {{ url }}
+{% endfor %}
+{% endif %}
 {% if image_urls | length > 0 %}
     template.kubevirt.io/images: |
 {% for url in image_urls %}


### PR DESCRIPTION
**What this PR does / why we need it**:

With this change containerdisk urls for the templates are loaded from osinfo-db instead of specifying them manually (where applicable).

Overrides for centos-stream[8|9] are still needed because of CentOS still having no stable image urls. Containerdisks are added there for now too. The image urls are updated to the latest version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
