### PR TITLE
disable cdi garbage collector in e2e tests

### DIFF
--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -34,6 +34,9 @@ metadata:
   name: winrmcli
   namespace: kubevirt
 spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
   containers:
   - image: quay.io/kubevirt/winrmcli
     command: ["/bin/sh","-c"]


### PR DESCRIPTION
**What this PR does / why we need it**:
disable cdi garbage collector in e2e tests
this prevent deletion of imported datavolumes with operating systems 
Update script which retrieves kubevirt and cdi versions (previous solution is not working anymore)

**Release note**:
```
NONE
```
