### PR TITLE
add default network model virtio to linux templates

### DIFF
--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -129,6 +129,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -129,6 +129,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -129,6 +129,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -143,6 +143,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -123,6 +123,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -132,6 +132,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -134,6 +134,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -134,6 +134,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
           features:
             smm:
               enabled: true

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -129,6 +129,7 @@ objects:
             interfaces:
             - masquerade: {}
               name: default
+              model: virtio
         terminationGracePeriodSeconds: 180
         networks:
         - name: default


### PR DESCRIPTION
**What this PR does / why we need it**:
add default network model virtio to linux templates

Some linux templates were missing default network model. This PR adds default network model - virtio.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2103844

**Special notes for your reviewer**:

**Release note**:
```
add default network model virtio to linux templates

```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
