### PR TITLE
Windows 2022 template is missing vTPM and UEFI

### DIFF
--- a/templates/windows2k22.tpl.yaml
+++ b/templates/windows2k22.tpl.yaml
@@ -128,6 +128,7 @@ objects:
           features:
             acpi: {}
             apic: {}
+            smm: {}
             hyperv:
               relaxed: {}
               vapic: {}
@@ -143,6 +144,10 @@ objects:
               ipi: {}
               runtime: {}
               reset: {}
+          firmware:
+            bootloader:
+              efi:
+                secureBoot: true
           devices:
 {% if item.multiqueue %}
             networkInterfaceMultiqueue: True
@@ -169,6 +174,7 @@ objects:
                 bus: usb
                 name: tablet
 {% endif %}
+            tpm: {}
         terminationGracePeriodSeconds: 3600
         volumes:
         - dataVolume:


### PR DESCRIPTION
Signed-off-by: bmordeha <bmodeha@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Windows 2022 template is missing vTPM and UEFI
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add vTPM and UEFI to Windows 2022 template
```
