### PR TITLE
improve RHEL9 display name

### DIFF
--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
     template.kubevirt.io/deprecated: "true"
-    openshift.io/display-name: "CentOS 6.0+ VM"
+    openshift.io/display-name: "CentOS 6 VM"
     description: >-
       Template for CentOS 6 VM or newer.
       A PVC with the CentOS disk image must be available.

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
-    openshift.io/display-name: "CentOS 7.0+ VM"
+    openshift.io/display-name: "CentOS 7 VM"
     description: >-
       Template for CentOS 7 VM or newer.
       A PVC with the CentOS disk image must be available.

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 7.0+ VM"
+    openshift.io/display-name: "Red Hat Enterprise Linux 7 VM"
     description: >-
       Template for Red Hat Enterprise Linux 7 VM or newer.
       A PVC with the RHEL disk image must be available.

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    openshift.io/display-name: "Red Hat Enterprise Linux 8 VM"
     description: >-
       Template for Red Hat Enterprise Linux 8 VM or newer.
       A PVC with the RHEL disk image must be available.

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -3,7 +3,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 9.0 VM"
+    openshift.io/display-name: "Red Hat Enterprise Linux 9 VM"
     description: >-
       Template for Red Hat Enterprise Linux 9 VM or newer.
       A PVC with the RHEL disk image must be available.


### PR DESCRIPTION
"Red Hat Enterprise Linux 9 VM" is visually cleaner and more precise display name now that RHEL 9.1 is available as is the default.

```release-note
NONE
```
