### PR TITLE
increase timeout for windows vms in tests

### DIFF
--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -48,6 +48,7 @@ restartPolicy: Always
 EOF
 
 timeout=2000
+vm_timeout=3600
 sample=10
 current_time=0
 
@@ -115,7 +116,7 @@ run_vm(){
     # start vm
     ./virtctl start $vm_name -n $namespace
 
-    oc wait --for=condition=Ready --timeout=${timeout}s vm/$vm_name -n $namespace
+    oc wait --for=condition=Ready --timeout=${vm_timeout}s vm/$vm_name -n $namespace
 
     # get ip address of vm
     ipAddressVMI=$(oc get vmi $vm_name -o json -n $namespace| jq -r '.status.interfaces[0].ipAddress')


### PR DESCRIPTION
**What this PR does / why we need it**:
increase timeout for windows vms in tests
Increase timeout for waiting for VM to be up.

This should fix failing tests in https://github.com/openshift/release/pull/34167
**Release note**:
```
NONE

```
