### PR TITLE
decrease dv size of windows in e2e tests

### DIFF
--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -23,7 +23,7 @@ spec:
       - ReadWriteOnce
     resources:
       requests:
-        storage: 60Gi
+        storage: 20Gi
 EOF
 
 oc apply -f - <<EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
decrease dv size of windows in e2e tests
This change should reduce time needed to copy original windows image
Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
