### PR TITLE
docs: remove beta from rhel 9 guest os

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The table below lists the guest operating systems that are covered by the templa
 | Fedora | [fedora](templates/fedora.tpl.yaml) |
 | Red Hat Enterprise Linux 7 | [rhel7](templates/rhel7.tpl.yaml) |
 | Red Hat Enterprise Linux 8 | [rhel8](templates/rhel8.tpl.yaml) |
-| Red Hat Enterprise Linux 9 Beta | [rhel9](templates/rhel9.tpl.yaml) |
+| Red Hat Enterprise Linux 9 | [rhel9](templates/rhel9.tpl.yaml) |
 | Ubuntu | [ubuntu](templates/ubuntu.tpl.yaml) |
 | openSUSE Leap | [opensuse](templates/opensuse.tpl.yaml) |
 | CentOS 7 | [centos7](templates/centos7.tpl.yaml) |


### PR DESCRIPTION
RHEL 9 is no longer Beta and it is already GA.

Signed-off-by: Ben Oukhanov <boukhanov@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Remove "Beta" from RHEL 9 Guest OS name in README.md.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
N/A
```
