### PR TITLE
fix: remove TSC labels from worker nodes in e2e tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -206,6 +206,16 @@ then
     oc apply -n $namespace  -f dist/templates
 fi
 
+for node in $(oc get nodes -o name -l node-role.kubernetes.io/worker); do
+    tscLabel="$(oc describe $node | grep scheduling.node.kubevirt.io/tsc-frequency- | xargs | cut -d"=" -f1)"
+    # disable node labeller
+    oc annotate ${node} node-labeller.kubevirt.io/skip-node=true --overwrite
+    # remove tsc labels
+    oc label ${node} cpu-timer.node.kubevirt.io/tsc-frequency- --overwrite
+    oc label ${node} cpu-timer.node.kubevirt.io/tsc-scalable- --overwrite
+    oc label ${node} ${tscLabel}- --overwrite
+done
+
 if [[ $TARGET =~ windows.* ]]; then
   ./automation/test-windows.sh $TARGET
 else


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: remove TSC labels from worker nodes in e2e tests

Latest kubevirt version introduced tsc node selectors for windows vms. This is causing problems during scheduling of windows VM, which are in pending state, due to different tsc labels on nodes. Currently there is no easy fix in kubevirt, because it would break migration flow. Due to that, we have to disable node-labeller and remove the tsc labels from nodes, so virt-controller can schedule the VMs on more nodes. This approach will break migration flow, but in our tests we do not test it.

**Release note**:
```
NONE
```
