### PR TITLE
[WIP] POC Use scsi as the default bus in VM templates

### DIFF
--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -116,15 +116,15 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -116,15 +116,15 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -1,4 +1,4 @@
-{% set diskbus = diskbus |default("virtio") %}
+{% set diskbus = diskbus |default("scsi") %}
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -107,16 +107,16 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - bootOrder: 1
               disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -116,15 +116,15 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -127,18 +127,18 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
 {% if item.iothreads %}
               dedicatedIOThread: true
 {% endif %}
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -110,15 +110,15 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -116,18 +116,18 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
 {% if item.iothreads %}
               dedicatedIOThread: true
 {% endif %}
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -118,18 +118,18 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
 {% if item.iothreads %}
               dedicatedIOThread: true
 {% endif %}
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -118,18 +118,18 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
 {% if item.iothreads %}
               dedicatedIOThread: true
 {% endif %}
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -116,15 +116,15 @@ objects:
 {% if item.tablet %}
             inputs:
               - type: tablet
-                bus: virtio
+                bus: scsi
                 name: tablet
 {% endif %}
             disks:
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: rootdisk
             - disk:
-                bus: {{ diskbus | default("virtio") }}
+                bus: {{ diskbus | default("scsi") }}
               name: cloudinitdisk
             interfaces:
             - masquerade: {}

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -56,8 +56,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
-            "values": ["virtio"],
+            "message": "virtio and scsi disk bus types have better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio", "scsi"],
             "justWarning": true
           }, {
             "name": "windows-disk-bus",
@@ -150,7 +150,7 @@ objects:
             disks:
             - disk:
 {% if item.workload == "highperformance" %}
-                bus: virtio
+                bus: scsi
 {% else %}
                 bus: sata
 {% endif %}

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -56,7 +56,7 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
+            "message": "virtio and scsi disk bus types have better performance, install virtio drivers in VM and change bus type",
             "values": ["virtio"],
             "justWarning": true
           }, {
@@ -161,7 +161,7 @@ objects:
             disks:
             - disk:
 {% if item.workload == "highperformance" %}
-                bus: virtio
+                bus: scsi
 {% else %}
                 bus: sata
 {% endif %}

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -56,8 +56,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
-            "values": ["virtio"],
+            "message": "virtio and scsi disk bus types have better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio", "scsi"],
             "justWarning": true
           }, {
             "name": "windows-disk-bus",
@@ -150,7 +150,7 @@ objects:
             disks:
             - disk:
 {% if item.workload == "highperformance" %}
-                bus: virtio
+                bus: scsi
 {% else %}
                 bus: sata
 {% endif %}

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -56,8 +56,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
-            "values": ["virtio"],
+            "message": "virtio and scsi disk bus types have better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio", "scsi"],
             "justWarning": true
           }, {
             "name": "windows-disk-bus",
@@ -150,7 +150,7 @@ objects:
             disks:
             - disk:
 {% if item.workload == "highperformance" %}
-                bus: virtio
+                bus: scsi
 {% else %}
                 bus: sata
 {% endif %}

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -56,8 +56,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
-            "values": ["virtio"],
+            "message": "virtio and scsi disk bus types have better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio", "scsi"],
             "justWarning": true
           }, {
             "name": "windows-disk-bus",
@@ -150,7 +150,7 @@ objects:
             disks:
             - disk:
 {% if item.workload == "highperformance" %}
-                bus: virtio
+                bus: scsi
 {% else %}
                 bus: sata
 {% endif %}

--- a/templates/windows2k22.tpl.yaml
+++ b/templates/windows2k22.tpl.yaml
@@ -56,8 +56,8 @@ objects:
             "path": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "valid": "jsonpath::.spec.domain.devices.disks[*].disk.bus",
             "rule": "enum",
-            "message": "virtio disk bus type has better performance, install virtio drivers in VM and change bus type",
-            "values": ["virtio"],
+            "message": "virtio and scsi disk bus types have better performance, install virtio drivers in VM and change bus type",
+            "values": ["virtio", "scsi"],
             "justWarning": true
           }, {
             "name": "windows-disk-bus",
@@ -155,7 +155,7 @@ objects:
             disks:
             - disk:
 {% if item.workload == "highperformance" %}
-                bus: virtio
+                bus: scsi
 {% else %}
                 bus: sata
 {% endif %}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Virtio-blk disks consume addresses on the PCI bus, which is a significant limitation. Since performance parity has been shown between virtio-scsi and virtio-blk it makes sense to standardize the former.

This Pull Request updates the VM templates so, by default and when possible, disks are created using the SCSI bus.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use SCSI as the default bus in VM templates
```
