### PR TITLE
fix: add bind immediate annotation to test datavolume

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -23,6 +23,8 @@ oc apply -n $namespace -f - <<EOF
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
   name: ${dv_name}
 spec:
   source:

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -12,6 +12,8 @@ oc apply -n ${namespace} -f - <<EOF
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
   name: ${dv_name}
 spec:
   source:


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add bind immediate annotation to test datavolume

the default storageClass in e2e tests requests WFFC mode. Currently when original datavolume is created in e2e tests, it is in pending state, because there is no object which will consume it. This commit adds special annotation
cdi.kubevirt.io/storage.bind.immediate.requested
to windows and linux original datavolume,
which allows to import datavolume without consumer.

**Release note**:
```
NONE
```
