### PR TITLE
fix: increase required memory for ubuntu small template

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -300,8 +300,8 @@
       src: ubuntu.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: small,  workload: desktop, memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: False}
-    - {flavor: small,  workload: server,  memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
+    - {flavor: small,  workload: desktop, memsize: "3Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: False}
+    - {flavor: small,  workload: server,  memsize: "3Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: True}
     - {flavor: medium, workload: desktop, memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: False}
     - {flavor: medium, workload: server,  memsize: "4Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True, default: False}
     - {flavor: large,  workload: desktop, memsize: "8Gi", cpus: 2, iothreads: False, emulatorthread: False, tablet: True, default: False}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: increase required memory for ubuntu small template
feat: update osinfo db to latest

Newest ubuntu 23.4 requires at least 3GB memory. This commit updates small ubuntu template. It increases memory request to 3GB.

**Release note**:
```
Increase memory request in ubuntu small template to 3GB
update osinfo-db to latest
```
