### PR TITLE
fix: custom configuration of crio in testing cluster

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -102,6 +102,21 @@ EOF
   oc wait --for=condition=Updated --timeout=900s machineconfigpool worker
 fi
 
+DEBUG_NS=debug-ns
+oc create ns ${DEBUG_NS}
+oc label ns ${DEBUG_NS} security.openshift.io/scc.podSecurityLabelSync=false --overwrite
+oc label ns ${DEBUG_NS} pod-security.kubernetes.io/enforce=privileged --overwrite
+
+NODES=$(oc get nodes -o json | jq -r .items[].metadata.name)
+
+while IFS= read -r node
+do
+	echo "setting device_ownership_from_security_context for ${node}.."
+	oc debug node/${node} --to-namespace ${DEBUG_NS} -- chroot /host sed -i '/^\[crio\.runtime\]/a device_ownership_from_security_context = true' /etc/crio/crio.conf
+	echo "restarting crio service on ${node}"
+	oc debug node/${node} --to-namespace ${DEBUG_NS} -- chroot /host systemctl restart crio
+done <<< "${NODES}"
+
 namespace="kubevirt"
 
 _curl() {


### PR DESCRIPTION
**What this PR does / why we need it**:
our e2e are not working due to permission issue in crio.
https://github.com/cri-o/cri-o/pull/7192 should revert the change.
Until that revert PR is released and available in ci envs, we have to
set special configuration on crio on all nodes
**Release note**:
```
NONE

```
