### PR TITLE
feat: replace vm.spec.template.spec.domain.resources.requests.memory …

### DIFF
--- a/automation/validate-min-memory-consistency.py
+++ b/automation/validate-min-memory-consistency.py
@@ -23,7 +23,7 @@ def newestOsLabel(template):
 
 def minMemoryReqInTemplate(template):
     object = template["objects"][0]
-    min_str = object["spec"]["template"]["spec"]["domain"]["resources"]["requests"]["memory"]
+    min_str = object["spec"]["template"]["spec"]["domain"]["memory"]["guest"]
     if min_str.startswith("${"):
         for param in template["parameters"]:
             if param["name"] == min_str[2:-1]:

--- a/templates/README.md
+++ b/templates/README.md
@@ -76,7 +76,7 @@ metadata:
     # The jsonpath root is the objects: element of the template
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.cores
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -211,7 +211,7 @@ metadata:
     # The jsonpath root is the spec: element of the VM object
     template.kubevirt.io/keep: |
       /template.spec.domain.cpu.cores
-      /template.spec.domain.resources.requests.memory
+      /template.spec.domain.memory.guest
       /template.spec.domain.devices.disks
       /template.spec.volumes
       /template.spec.networks

--- a/templates/VALIDATION.md
+++ b/templates/VALIDATION.md
@@ -59,12 +59,12 @@ the `jsonpath::` prefix.
 
 good:
 ```
-jsonpath::.spec.domain.resources.requests.memory
+jsonpath::.spec.domain.memory.guest
 ```
 
 bad:
 ```
-.spec.domain.resources.requests.memory
+.spec.domain.memory.guest
 ```
 
 ### Validation rules

--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -31,7 +31,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -64,7 +64,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -107,9 +107,8 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -31,7 +31,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -64,7 +64,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -107,9 +107,8 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -21,7 +21,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -54,7 +54,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -97,9 +97,8 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             networkInterfaceMultiqueue: true
             useVirtioTransitional: true

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -31,7 +31,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -64,7 +64,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -107,9 +107,8 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -30,7 +30,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -63,7 +63,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -118,9 +118,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -25,7 +25,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -58,7 +58,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -101,9 +101,8 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -25,7 +25,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -58,7 +58,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -107,9 +107,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -27,7 +27,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -60,7 +60,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -109,9 +109,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -27,7 +27,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -60,7 +60,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -109,9 +109,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -31,7 +31,7 @@ metadata:
       /objects[0].spec.template.spec.domain.cpu.sockets
       /objects[0].spec.template.spec.domain.cpu.cores
       /objects[0].spec.template.spec.domain.cpu.threads
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -64,7 +64,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64|all.ram"] }}
@@ -107,9 +107,8 @@ objects:
 {% if cpumodel |default("") %}
             model: {{ cpumodel }}
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           devices:
             rng: {}
             networkInterfaceMultiqueue: true

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -18,7 +18,7 @@ metadata:
     defaults.template.kubevirt.io/network: default
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.cores
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -47,7 +47,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64.ram"] }}
@@ -122,9 +122,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           features:
             acpi: {}
             apic: {}

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -18,7 +18,7 @@ metadata:
     defaults.template.kubevirt.io/network: default
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.cores
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -47,7 +47,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.architecture=x86_64.ram"] }}
@@ -128,9 +128,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           features:
             acpi: {}
             apic: {}

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -18,7 +18,7 @@ metadata:
     defaults.template.kubevirt.io/network: default
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.cores
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -47,7 +47,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
@@ -122,9 +122,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           features:
             acpi: {}
             apic: {}

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -18,7 +18,7 @@ metadata:
     defaults.template.kubevirt.io/network: default
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.cores
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -47,7 +47,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
@@ -122,9 +122,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           features:
             acpi: {}
             apic: {}

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -18,7 +18,7 @@ metadata:
     defaults.template.kubevirt.io/network: default
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.cores
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -47,7 +47,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
@@ -122,9 +122,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           features:
             acpi: {}
             apic: {}

--- a/templates/windows2k22.tpl.yaml
+++ b/templates/windows2k22.tpl.yaml
@@ -18,7 +18,7 @@ metadata:
     defaults.template.kubevirt.io/network: default
     template.kubevirt.io/editable: |
       /objects[0].spec.template.spec.domain.cpu.cores
-      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.memory.guest
       /objects[0].spec.template.spec.domain.devices.disks
       /objects[0].spec.template.spec.volumes
       /objects[0].spec.template.spec.networks
@@ -47,7 +47,7 @@ objects:
         [
           {
             "name": "minimal-required-memory",
-            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",
             "message": "This VM requires more memory.",
             "min": {{ lookup('osinfo', osinfoname)["minimum_resources.0.ram"] }}
@@ -122,9 +122,8 @@ objects:
 {% if item.emulatorthread %}
             isolateEmulatorThread: True
 {% endif %}
-          resources:
-            requests:
-              memory: {{ item.memsize }}
+          memory:
+            guest: {{ item.memsize }}
           features:
             acpi: {}
             apic: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: replace vm.spec.template.spec.domain.resources.requests.memory with vm.spec.template.spec.domain.memory.guest

the path vm.spec.template.spec.domain.memory.guest is used for setting the memory the guest can use.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2174892

**Release note**:

```
feat: replace vm.spec.template.spec.domain.resources.requests.memory with vm.spec.template.spec.domain.memory.guest
```
