### PR TITLE
Annotate Windows Server 2012 as deprecated

### DIFF
--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -3,7 +3,7 @@
 set -ex
 
 namespace="kubevirt"
-template_name="windows2k12r2"
+template_name="windows2k22"
 username="Administrator"
 
 dv_name="${TARGET}-datavolume-original"

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -3,6 +3,7 @@ kind: Template
 metadata:
   name: windows2k12r2-{{ item.workload }}-{{ item.flavor }}
   annotations:
+    template.kubevirt.io/deprecated: "true"
     openshift.io/display-name: "Microsoft Windows Server 2012 R2 VM"
     description: >-
       Template for Microsoft Windows Server 2012 R2 VM.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an annotation to the Windows Server 2012 R2 template to tag it as deprecated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Windows Server 2012 R2 is now deprecated
```
