### PR TITLE
feat: add podman to builder image

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@
 FROM quay.io/fedora/fedora:latest
 
 # Install dependencies and tools
-RUN dnf install -y jq ansible python3-gobject python3-openshift libosinfo intltool make git findutils expect golang
+RUN dnf install -y jq ansible python3-gobject python3-openshift libosinfo intltool make git findutils expect golang podman
 
 # Allow writes to /etc/passwd so a user for ansible can be added by CI commands
 RUN chmod a+w /etc/passwd


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add podman to builder image

To make ci work again, we will need to have podman in test env. Podman will help to download VM image and push it to internal ocp registry

**Release note**:
```
NONE

```
