### PR TITLE
Add windows version to VM name

### DIFF
--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -180,7 +180,7 @@ parameters:
 - name: NAME
   description: VM name
   generate: expression
-  from: "windows-[a-z0-9]{6}"
+  from: "windows10-[a-z0-9]{6}"
 - name: DATA_SOURCE_NAME
   description: Name of the DataSource to clone
   value: win10

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -192,7 +192,7 @@ parameters:
 - name: NAME
   description: VM name
   generate: expression
-  from: "windows-[a-z0-9]{6}"
+  from: "windows11-[a-z0-9]{6}"
 - name: DATA_SOURCE_NAME
   description: Name of the DataSource to clone
   value: win11

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -181,7 +181,7 @@ parameters:
 - name: NAME
   description: VM name
   generate: expression
-  from: "windows-[a-z0-9]{6}"
+  from: "windows2012-[a-z0-9]{6}"
 - name: DATA_SOURCE_NAME
   description: Name of the DataSource to clone
   value: win2k12r2

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -180,7 +180,7 @@ parameters:
 - name: NAME
   description: VM name
   generate: expression
-  from: "windows-[a-z0-9]{6}"
+  from: "windows2016-[a-z0-9]{6}"
 - name: DATA_SOURCE_NAME
   description: Name of the DataSource to clone
   value: win2k16

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -180,7 +180,7 @@ parameters:
 - name: NAME
   description: VM name
   generate: expression
-  from: "windows-[a-z0-9]{6}"
+  from: "windows2019-[a-z0-9]{6}"
 - name: DATA_SOURCE_NAME
   description: Name of the DataSource to clone
   value: win2k19

--- a/templates/windows2k22.tpl.yaml
+++ b/templates/windows2k22.tpl.yaml
@@ -186,7 +186,7 @@ parameters:
 - name: NAME
   description: VM name
   generate: expression
-  from: "windows-[a-z0-9]{6}"
+  from: "windows2022-[a-z0-9]{6}"
 - name: DATA_SOURCE_NAME
   description: Name of the DataSource to clone
   value: win2k22


### PR DESCRIPTION
**What this PR does / why we need it**:
Added the version of Windows to the names of virtual machines.

**Which issue(s) this PR fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2151413

**Release note**:
```release-note
Windows VM names include versions.
```
