### PR TITLE
Remove 'codingben' from the OWNRES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,4 +11,3 @@ reviewers:
   - lyarwood
   - jcanocan
   - opokornyy
-  - codingben


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove 'codingben' from the OWNRES

**Release note**:
```release-note
None
```
