### PR TITLE
Set architecture to amd64 across all templates

### DIFF
--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -96,6 +96,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -96,6 +96,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -86,6 +86,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -96,6 +96,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -95,6 +95,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
           features:
             smm:

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -90,6 +90,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -90,6 +90,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -92,6 +92,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -92,6 +92,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -96,6 +96,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
 {% if item.iothreads %}
           ioThreadsPolicy: shared

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -101,6 +101,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
           clock:
             utc: {}

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -107,6 +107,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
           clock:
             utc: {}

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -102,6 +102,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
           clock:
             utc: {}

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -101,6 +101,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
           clock:
             utc: {}

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -101,6 +101,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
           clock:
             utc: {}

--- a/templates/windows2k22.tpl.yaml
+++ b/templates/windows2k22.tpl.yaml
@@ -101,6 +101,7 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
+        architecture: amd64
         domain:
           clock:
             utc: {}


### PR DESCRIPTION
/cc @0xFelix 
/cc @ksimon1 

**What this PR does / why we need it**:

The current set of templates are only verified on amd64 so to avoid users attempting to run them on aarch64 etc set the architecture within the VirtualMachineInstanceSpec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The architecture of each `VirtualMachine` is now  set to `amd64` within the `VirtualMachineInstanceSpec`.
```
