### PR TITLE
chore: drop fedora tiny templates

### DIFF
--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -236,9 +236,6 @@
       src: fedora.tpl.yaml
       dest: "{{ playbook_dir }}/dist/templates/{{ os }}-{{ item.workload }}-{{ item.flavor }}.yaml"
     with_items:
-    - {flavor: tiny,   workload: desktop,         memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
-    - {flavor: tiny,   workload: server,          memsize: "1Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: False}
-    - {flavor: tiny,   workload: highperformance, memsize: "1Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
     - {flavor: small,  workload: desktop,         memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: True,  default: False}
     - {flavor: small,  workload: server,          memsize: "2Gi", cpus: 1, iothreads: False, emulatorthread: False, tablet: False, default: True}
     - {flavor: small,  workload: highperformance, memsize: "2Gi", cpus: 1, iothreads: True,  emulatorthread: True,  tablet: False, default: False}
@@ -253,7 +250,7 @@
       icon: fedora
       majorrelease: fedora
       oslabels: "{{ fedora_labels }}"
-      osinfoname: "{{ oslabels[0] }}"
+      osinfoname: "{{ oslabels | last }}"
       cloudusername: fedora
       containerdisk_urls: "{{ fedora_containerdisk_urls }}"
       image_urls: "{{ fedora_image_urls }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: drop fedora tiny templates
newest fedora 40 has 2Gi required memory. This means, tiny template
does not have accomplished with minimal requirements and will be
dropped.

**Release note**:
```
Drop Fedora tiny templates
```
/cc @0xFelix, @lyarwood, @dominikholler, @geetikakay 
