### PR TITLE
feat: use spec.runStrategy instead of spec.running

### DIFF
--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -85,7 +85,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -85,7 +85,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -75,7 +75,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -85,7 +85,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -84,7 +84,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -79,7 +79,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -79,7 +79,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -81,7 +81,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -81,7 +81,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -85,7 +85,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -90,7 +90,7 @@ objects:
             kind: DataSource
             name: ${DATA_SOURCE_NAME}
             namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -96,7 +96,7 @@ objects:
             kind: DataSource
             name: ${DATA_SOURCE_NAME}
             namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -91,7 +91,7 @@ objects:
             kind: DataSource
             name: ${DATA_SOURCE_NAME}
             namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -90,7 +90,7 @@ objects:
             kind: DataSource
             name: ${DATA_SOURCE_NAME}
             namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -90,7 +90,7 @@ objects:
             kind: DataSource
             name: ${DATA_SOURCE_NAME}
             namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/templates/windows2k22.tpl.yaml
+++ b/templates/windows2k22.tpl.yaml
@@ -90,7 +90,7 @@ objects:
             kind: DataSource
             name: ${DATA_SOURCE_NAME}
             namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

VM templates are using spec.running and should use spec.runStrategy instead because spec.running is
planned to be deprecated soon.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #581

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use spec.runStrategy instead of spec.running
```