### PR TITLE
fix: Enable networkInterfaceMultiqueue only if sockets > 1

### DIFF
--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -112,7 +112,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/centos-stream9.tpl.yaml
+++ b/templates/centos-stream9.tpl.yaml
@@ -112,7 +112,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/centos6.tpl.yaml
+++ b/templates/centos6.tpl.yaml
@@ -101,7 +101,9 @@ objects:
           memory:
             guest: {{ item.memsize }}
           devices:
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
             useVirtioTransitional: true
             rng: {}
 {% if item.tablet %}

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -112,7 +112,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -123,7 +123,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/opensuse.tpl.yaml
+++ b/templates/opensuse.tpl.yaml
@@ -106,7 +106,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/rhel7.tpl.yaml
+++ b/templates/rhel7.tpl.yaml
@@ -112,7 +112,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/rhel8.tpl.yaml
+++ b/templates/rhel8.tpl.yaml
@@ -114,7 +114,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/rhel9.tpl.yaml
+++ b/templates/rhel9.tpl.yaml
@@ -114,7 +114,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/ubuntu.tpl.yaml
+++ b/templates/ubuntu.tpl.yaml
@@ -112,7 +112,9 @@ objects:
             guest: {{ item.memsize }}
           devices:
             rng: {}
+{% if item.cpus > 1 %}
             networkInterfaceMultiqueue: true
+{% endif %}
 {% if item.tablet %}
             inputs:
               - type: tablet

--- a/templates/windows10.tpl.yaml
+++ b/templates/windows10.tpl.yaml
@@ -149,7 +149,7 @@ objects:
               efi:
                 secureBoot: true
           devices:
-{% if item.multiqueue %}
+{% if item.multiqueue and item.cpus > 1 %}
             networkInterfaceMultiqueue: True
 {% endif %}
             disks:

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -155,7 +155,7 @@ objects:
               efi:
                 secureBoot: true
           devices:
-{% if item.multiqueue %}
+{% if item.multiqueue and item.cpus > 1 %}
             networkInterfaceMultiqueue: True
 {% endif %}
             disks:

--- a/templates/windows2k12.tpl.yaml
+++ b/templates/windows2k12.tpl.yaml
@@ -150,7 +150,7 @@ objects:
               efi:
                 secureBoot: true
           devices:
-{% if item.multiqueue %}
+{% if item.multiqueue and item.cpus > 1 %}
             networkInterfaceMultiqueue: True
 {% endif %}
             disks:

--- a/templates/windows2k16.tpl.yaml
+++ b/templates/windows2k16.tpl.yaml
@@ -149,7 +149,7 @@ objects:
               efi:
                 secureBoot: true
           devices:
-{% if item.multiqueue %}
+{% if item.multiqueue and item.cpus > 1 %}
             networkInterfaceMultiqueue: True
 {% endif %}
             disks:

--- a/templates/windows2k19.tpl.yaml
+++ b/templates/windows2k19.tpl.yaml
@@ -149,7 +149,7 @@ objects:
               efi:
                 secureBoot: true
           devices:
-{% if item.multiqueue %}
+{% if item.multiqueue and item.cpus > 1 %}
             networkInterfaceMultiqueue: True
 {% endif %}
             disks:

--- a/templates/windows2k22.tpl.yaml
+++ b/templates/windows2k22.tpl.yaml
@@ -149,7 +149,7 @@ objects:
               efi:
                 secureBoot: true
           devices:
-{% if item.multiqueue %}
+{% if item.multiqueue and item.cpus > 1 %}
             networkInterfaceMultiqueue: True
 {% endif %}
             disks:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Enable networkInterfaceMultiqueue only if the amount of sockets is greater than one, since networkInterfaceMultiqueue requires at least two sockets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
networkInterfaceMultiqueue is only enabled if the template has more than one socket
```
