### PR TITLE
fix: make generate called inside unit-test.sh

### DIFF
--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -ex
-make generate
 
 #syntax check
 templates=$(ls dist/templates/*)

--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ e2e-tests:
 go-tests:
 	go test -v ./tests/
 
-unit-tests:
+unit-tests: generate
 	./automation/unit-tests.sh
 
 validate-no-offensive-lang:


### PR DESCRIPTION
The 'make generate' command is currently being called within the unit-test script instead of being added as a dependency in the makefile.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The 'make generate' command is currently being called within the unit-test script instead of being added as a dependency in the makefile.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
