### PR TITLE
fix: make unit-tests can be called more than once

### DIFF
--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -5,6 +5,8 @@ set -ex
 templates=$(ls dist/templates/*)
 namespace="kubevirt"
 
+oc delete namespace ${namespace} || true
+
 echo "Testing fresh installation..."
 oc apply -f - <<EOF
 apiVersion: v1


### PR DESCRIPTION
To enable running the unit tests multiple times, the existing templates are deleted before creating new ones. This approach allows for the successful execution of unit tests even if the templates already exist in the cluster.

If the templates do not exist, the 'oc delete' command would fail, which is why '|| true' is used.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: ability to run unit tests consecutively

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
