### PR TITLE
fix: verification of the python openshift requirement

### DIFF
--- a/automation/unit-tests.sh
+++ b/automation/unit-tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -ex
 
+# dependency check
+pip show -q openshift
+
 #syntax check
 templates=$(ls dist/templates/*)
 namespace="kubevirt"


### PR DESCRIPTION
The unit-tests.sh script may fail at an advanced stage if the python openShift module is not installed. Failing at the initial step alerts the user to this requirement.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Fail early

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
