### PR TITLE
centos-7,centos-stream8: Mark as deprecated with recent EOLs

### DIFF
--- a/templates/centos-stream8.tpl.yaml
+++ b/templates/centos-stream8.tpl.yaml
@@ -3,6 +3,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
+    template.kubevirt.io/deprecated: "true"
     openshift.io/display-name: "CentOS Stream 8 VM"
     description: >-
       Template for CentOS Stream 8 VM or newer.

--- a/templates/centos7.tpl.yaml
+++ b/templates/centos7.tpl.yaml
@@ -3,6 +3,7 @@ kind: Template
 metadata:
   name: {{ os }}-{{ item.workload }}-{{ item.flavor }}
   annotations:
+    template.kubevirt.io/deprecated: "true"
     openshift.io/display-name: "CentOS 7 VM"
     description: >-
       Template for CentOS 7 VM or newer.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Mark CentOS 7 and Stream 8 as deprecated with recent EOLs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CentOS 7 and Stream 8 templates are now deprecated
```
