### PR TITLE
fix: check if TARGET environment variable is set for e2e testing

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -66,6 +66,12 @@ function latest_version() {
     tail -n1
 }
 
+# Check if the TARGET environment variable is set
+if [ -z "$TARGET" ]; then
+  echo "Error: a target is needed: please set the TARGET environment variable"
+  exit 1
+fi
+
 # Latest released Kubevirt version
 export KUBEVIRT_VERSION=$(latest_version "kubevirt")
 


### PR DESCRIPTION
The end-to-end tests require the TARGET environment variable to be set. It is better to catch any failures related to this early on.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Fail early

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
