### PR TITLE
fix: add submodule initialization in update-osinfo-db

### DIFF
--- a/makefile
+++ b/makefile
@@ -44,6 +44,7 @@ generate: generate-templates.yaml $(METASOURCES)
 	ansible-playbook generate-templates.yaml
 
 update-osinfo-db:
+	git submodule init
 	git submodule update --remote osinfo-db
 
 .PHONY: all generate release e2e-tests unit-tests go-tests


### PR DESCRIPTION
This change enables the use of 'make update-osinfo-db' without the need for any additional steps.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: User friendly

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
