### PR TITLE
fix: patching cdi after availability

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -145,7 +145,7 @@ oc apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VE
 
 sample=10
 current_time=0
-timeout=300
+timeout=600
 
 # Waiting for kubevirt cr to report available
 oc wait --for=condition=Available --timeout=${timeout}s kubevirt/kubevirt -n $namespace
@@ -179,9 +179,9 @@ echo "Deploying CDI"
 oc apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-operator.yaml
 oc apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/$CDI_VERSION/cdi-cr.yaml
 
-oc patch cdi cdi -n cdi --patch '{"spec": {"config": {"dataVolumeTTLSeconds": -1}}}' --type merge
-
 oc wait --for=condition=Available --timeout=${timeout}s CDI/cdi -n cdi
+
+oc patch cdi cdi -n cdi --patch '{"spec": {"config": {"dataVolumeTTLSeconds": -1}}}' --type merge
 
 oc apply -f - <<EOF
 ---


### PR DESCRIPTION
This error was identified while using CodeReady Workspaces with limited resources. The DataVolume specified in the test-linux.sh file did not fully deploy, resulting in failed end-to-end tests.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: fixes error

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
