### PR TITLE
fix: e2e-tests preconditions in makefile

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -127,10 +127,6 @@ then
     export CLUSTERENV=$ocenv
 fi
 
-git submodule update --init
-
-make generate
-
 #set terminationGracePeriodSeconds to 0
 for filename in dist/templates/*; do
     sed -i -e 's/^\(\s*terminationGracePeriodSeconds\s*:\s*\).*/\10/' $filename

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ dist/common-templates.yaml: generate
 release: dist/common-templates.yaml
 	cp dist/common-templates.yaml dist/common-templates-$(VERSION).yaml
 
-e2e-tests:
+e2e-tests: update-osinfo-db generate
 	./automation/test.sh
 
 go-tests:


### PR DESCRIPTION
The preconditions for the end-to-end (e2e) tests were previously embedded within the script. This update ensures that unnecessary oc commands are not executed in the event of an error during the generation process.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: fail faster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
