### PR TITLE
fix: remove tiny size from e2e test for fedora

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -59,6 +59,10 @@ EOF
 sizes=("tiny" "small" "medium" "large")
 workloads=("desktop" "server" "highperformance")
 
+if [[ $TARGET =~ fedora.* ]]; then
+  workloads=("small" "medium" "large")
+fi
+
 if [[ $TARGET =~ centos6.* ]]; then
   workloads=("server")
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: remove tiny size from e2e test for fedora

the fedora tiny size was removed and e2e test is failing because it is trying to create vm with it.

**Release note**:
```
NONE

```
