### PR TITLE
Windows 11: enable TPM and EFI persistence

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -151,7 +151,7 @@ timeout=600
 # Waiting for kubevirt cr to report available
 oc wait --for=condition=Available --timeout=${timeout}s kubevirt/kubevirt -n $namespace
 
-oc patch kubevirt kubevirt -n $namespace --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["DataVolumes", "CPUManager", "NUMA", "DownwardMetrics"]}}}}'
+oc patch kubevirt kubevirt -n $namespace --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["DataVolumes", "CPUManager", "NUMA", "DownwardMetrics", "VMPersistentState"]}}}}'
 
 key="/tmp/secrets/accessKeyId"
 token="/tmp/secrets/secretKey"

--- a/templates/windows11.tpl.yaml
+++ b/templates/windows11.tpl.yaml
@@ -154,6 +154,7 @@ objects:
             bootloader:
               efi:
                 secureBoot: true
+                persistent: true
           devices:
 {% if item.multiqueue and item.cpus > 1 %}
             networkInterfaceMultiqueue: True
@@ -180,7 +181,8 @@ objects:
                 bus: usb
                 name: tablet
 {% endif %}
-            tpm: {}
+            tpm:
+              persistent: true
         terminationGracePeriodSeconds: 3600
         volumes:
         - dataVolume:

--- a/templates/windows2k22.tpl.yaml
+++ b/templates/windows2k22.tpl.yaml
@@ -148,6 +148,7 @@ objects:
             bootloader:
               efi:
                 secureBoot: true
+                persistent: true
           devices:
 {% if item.multiqueue and item.cpus > 1 %}
             networkInterfaceMultiqueue: True
@@ -174,7 +175,8 @@ objects:
                 bus: usb
                 name: tablet
 {% endif %}
-            tpm: {}
+            tpm:
+              persistent: true
         terminationGracePeriodSeconds: 3600
         volumes:
         - dataVolume:


### PR DESCRIPTION
**What this PR does / why we need it**:
The Windows 11 template enables TPM and EFI, since both a required. However, they were both non-persistent by default, which means bitlocker won't work. Also, in recent versions of Windows 11, bitlocker requires both TPM and EFI to be persistent. This enables persistent EFI and TPM, which requires a RWO FS storage class to be present.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Windows 11 now defaults to persistent TPM and EFI. This requires a storage class capable of ReadWriteMany Filesystem
```
