### PR TITLE
fix: use spec.storage in DV in e2e tests

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -31,7 +31,7 @@ spec:
     registry:
       url: "${image_url}"
       ${secret_ref}
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:

--- a/automation/test-windows.sh
+++ b/automation/test-windows.sh
@@ -20,7 +20,7 @@ spec:
     registry:
       secretRef: common-templates-container-disk-puller
       url: "docker://quay.io/openshift-cnv/ci-common-templates-images:${TARGET}"
-  pvc:
+  storage:
     accessModes:
       - ReadWriteOnce
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: use spec.storage in DV in e2e tests

Switch to spec.storage in e2e tests DVs.
This should fix the 500 error we are experiencing during the
clone of the VM disk.

**Release note**:
```
NONE
```
