### PR TITLE
fix: remove call to legacy template validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ common-templates*.yaml
 releases.json
 ssp-operator-deploy-key
 virtctl
-kubevirt-template-validator/

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -200,14 +200,13 @@ EOF
 
 if [ "${CLUSTERENV}" == "$ocenv" ]
 then
-    export VALIDATOR_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt-template-validator/releases | \
+    # Deploy ssp-operator
+    export SSP_VERSION=$(curl -s https://api.github.com/repos/kubevirt/ssp-operator/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
-
-    git clone -b ${VALIDATOR_VERSION} --depth 1 https://github.com/kubevirt/kubevirt-template-validator kubevirt-template-validator
-    VALIDATOR_DIR="kubevirt-template-validator/cluster/ocp4"
-    sed -i 's/RELEASE_TAG/'$VALIDATOR_VERSION'/' ${VALIDATOR_DIR}/service.yaml
-    oc apply -n kubevirt -f ${VALIDATOR_DIR}
-    oc wait --for=condition=Available --timeout=${timeout}s deployment/virt-template-validator -n $namespace
+    oc apply -f https://github.com/kubevirt/ssp-operator/releases/download/${SSP_VERSION}/ssp-operator.yaml
+    oc apply -f https://github.com/kubevirt/ssp-operator/releases/download/${SSP_VERSION}/olm-crds.yaml
+    oc apply -f https://github.com/kubevirt/ssp-operator/releases/download/${SSP_VERSION}/olm-ssp-operator.clusterserviceversion.yaml
+    oc wait --for=condition=Available --timeout=${timeout}s deployment/ssp-operator -n $namespace
     # Apply templates
     echo "Deploying templates"
     oc apply -n $namespace  -f dist/templates


### PR DESCRIPTION
The template validator code is now located in the ssp-operator repository. To deploy the validator exclusively, additional changes are required in the ssp. However, experimentation indicates that these changes are not necessary for the end-to-end tests to function properly.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
