### PR TITLE
feat: disable Centos 6 on s390x architecture

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -7,6 +7,11 @@ namespace="kubevirt"
 ocenv="OC"
 k8senv="K8s"
 
+if [ "$TARGET" == "centos6" ] && [ "$(uname -m)" == "s390x" ]; then
+  echo "CentOS 6 does not support s390x."
+  exit 1
+fi
+
 image_url=""
 #set secret_ref only for rhel OSes
 secret_ref=""

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -1,7 +1,7 @@
 ---
 - connection: local
   hosts: 127.0.0.1
-  gather_facts: no
+  gather_facts: yes
   tasks:
   - name: Prepare dist directory
     file:
@@ -203,6 +203,7 @@
   - name: Load CentOS 6 versions
     set_fact:
       centos6_labels: "{{ lookup('osinfo', 'distro=centos') |map(attribute='short_id') |select('match', '^centos6\\.') |list |sort }}"
+    when: ansible_architecture != "s390x"
 
   - name: Generate CentOS 6 templates
     template:
@@ -220,6 +221,7 @@
       oslabels: "{{ centos6_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: centos
+    when: ansible_architecture != "s390x"
 
   - name: Load Fedora versions
     set_fact:


### PR DESCRIPTION
This commit disables the generation of templates for the s390x architecture, as there are no references to CentOS 6 in the osinfo-db for this architecture.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
