### PR TITLE
fix: fix minimum requirements in win2k25 template

### DIFF
--- a/osinfo-db-override/os/microsoft.com/win-2k25.xml
+++ b/osinfo-db-override/os/microsoft.com/win-2k25.xml
@@ -10,10 +10,10 @@
     <distro>win</distro>
     <resources arch="x86_64">
       <minimum>
-        <cpu>1000000000</cpu>
-        <n-cpus>2</n-cpus>
-        <ram>4294967296</ram>
-        <storage>68719476736</storage>
+        <cpu>1400000000</cpu>
+        <n-cpus>1</n-cpus>
+        <ram>536870912</ram>
+        <storage>34359738368</storage>
       </minimum>
     </resources>
   </os>

--- a/templates/windows2k25.tpl.yaml
+++ b/templates/windows2k25.tpl.yaml
@@ -73,12 +73,6 @@ objects:
             "rule": "enum",
             "message": "cd bus has to be sata",
             "values": ["sata"]
-          }, {
-            "name": "minimal-required-cores",
-            "path": "jsonpath::.spec.domain.cpu.cores",
-            "rule": "integer",
-            "message": "This VM requires more cores.",
-            "min": 2
           }
         ]
   spec:
@@ -121,7 +115,7 @@ objects:
               hyperv: {}
           cpu:
             sockets: {{ item.cpus }}
-            cores: 2
+            cores: 1
             threads: 1
 {% if item.iothreads or item.emulatorthread %}
             dedicatedCpuPlacement: True


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fix minimum requirements in win2k25 template

The win2k25 requirements https://learn.microsoft.com/en-us/windows-server/get-started/hardware-requirements?tabs=cpu#components


**Release note**:
```
NONE

```
