### PR TITLE
feat: disable Centos 7 on s390x architecture

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -12,6 +12,11 @@ if [ "$TARGET" == "centos6" ] && [ "$(uname -m)" == "s390x" ]; then
   exit 1
 fi
 
+if [ "$TARGET" == "centos7" ] && [ "$(uname -m)" == "s390x" ]; then
+  echo "CentOS 7 does not support s390x."
+  exit 1
+fi
+
 image_url=""
 #set secret_ref only for rhel OSes
 secret_ref=""

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -175,6 +175,7 @@
     set_fact:
       centos7_containerdisk_urls: "{{ lookup('osinfo', 'centos7.0') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'eq', 'containerdisk') |map(attribute='url') |map('replace', 'docker://', '') |list }}"
       centos7_image_urls: "{{ lookup('osinfo', 'centos7.0') |attr('image_list') |selectattr('architecture', 'eq', 'x86_64') |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+    when: ansible_architecture != "s390x"
 
   - name: Generate CentOS 7 templates
     template:
@@ -199,6 +200,7 @@
       cloudusername: centos
       containerdisk_urls: "{{ centos7_containerdisk_urls }}"
       image_urls: "{{ centos7_image_urls }}"
+    when: ansible_architecture != "s390x"
 
   - name: Load CentOS 6 versions
     set_fact:


### PR DESCRIPTION
This commit disables the generation of templates for the s390x architecture, as there are no references to CentOS 7 in the osinfo-db for this architecture.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
