### PR TITLE
fix: fedora workloads definition in function tests

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -65,7 +65,7 @@ sizes=("tiny" "small" "medium" "large")
 workloads=("desktop" "server" "highperformance")
 
 if [[ $TARGET =~ fedora.* ]]; then
-  workloads=("small" "medium" "large")
+  sizes=("small" "medium" "large")
 fi
 
 if [[ $TARGET =~ centos6.* ]]; then


### PR DESCRIPTION
This change resolves an issue where manually starting the Fedora end-to-end tests was not possible due to invalid workload values. It is important to note that the Fedora templates have changed the sizes, while the workloads remain the same, only including small, medium, and large.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
