### PR TITLE
README: use spec.runStrategy instead of spec.running

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -135,7 +135,7 @@ objects:
   metadata:
     name: ${NAME}
   spec:
-    running: false
+    runStrategy: Halted
     template:
       spec:
         domain:
@@ -235,7 +235,7 @@ metadata:
 # simply replaces the whole spec: with the current version
 # the user saved
 spec:
-  running: false
+  runStrategy: Halted
   template:
     spec:
       domain:


### PR DESCRIPTION
Just a small README update

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
