### PR TITLE
fix: disable efi bootloader in fedora for s390x

### DIFF
--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -100,9 +100,11 @@ objects:
           features:
             smm:
               enabled: true
+{% if ansible_architecture != 's390x' %}
           firmware:
             bootloader:
               efi: {}
+{% endif %}
 {% if item.iothreads %}
           ioThreadsPolicy: shared
 {% endif %}


### PR DESCRIPTION
Attempting to run it on other architectures (e.g., s390x) makes the image unbootable.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
