### PR TITLE
perf: optimizes check for updated machineconfigpool

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -154,9 +154,14 @@ spec:
     reservedSystemCPUs: "2"
 EOF
 
-  oc wait --for=condition=Updating --timeout=300s machineconfigpool worker
-  # it can take a while to enable CPU manager
-  oc wait --for=condition=Updated --timeout=900s machineconfigpool worker
+  # Verify if the machine configuration has been updated (this will increase test speed when running the second time)
+  machineconfigpool_updated=$(oc get machineconfigpool worker -o jsonpath='{range .status.conditions[*]}{.type}: {.status}{"\n"}{end}' | grep Updated | awk '{print $2}')
+
+  if [ $machineconfigpool_updated != "True" ]; then
+    oc wait --for=condition=Updating --timeout=300s machineconfigpool worker
+    # it can take a while to enable CPU manager
+    oc wait --for=condition=Updated --timeout=900s machineconfigpool worker
+  fi
 fi
 
 _curl() {


### PR DESCRIPTION
This optimization is particularly beneficial when running the test scripts a second time within the same cluster.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
