### PR TITLE
fix: address failing tests on Ubuntu

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -74,6 +74,7 @@ fi
 
 if [[ $TARGET =~ ubuntu.* ]]; then
   workloads=("desktop" "server")
+  sizes=("small" "medium" "large")
 fi
 
 if [[ $TARGET =~ opensuse.* ]]; then


### PR DESCRIPTION
The templates generated for Ubuntu are not of the tiny variant. The end-to-end tests attempted to run them but failed silently.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
