### PR TITLE
fix: patterns in expect script and adjust timeout/exit conditions

### DIFF
--- a/automation/connect_to_rhel_console.exp
+++ b/automation/connect_to_rhel_console.exp
@@ -10,5 +10,6 @@ expect {
     "*login*" {exit 0}
     "*Welcome*" {exit 0}
     "*A start job*" {exit 0}
-    exit 1 
+    timeout {exit 1}
+    eof {exit 1}
 }

--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -62,7 +62,7 @@ spec:
 EOF
 
 sizes=("tiny" "small" "medium" "large")
-workloads=("desktop" "server" "highperformance")
+workloads=("desktop" "server")
 
 if [[ $TARGET =~ fedora.* ]]; then
   sizes=("small" "medium" "large")


### PR DESCRIPTION
The issue identified was that the string "1" is recognized as a pattern. The latest version of CentOS Stream 9 includes this "pattern" in its boot sequence.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
