### PR TITLE
fix: increase timeout for end-to-end tests

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -44,7 +44,7 @@ spec:
         storage: 30Gi
 EOF
 
-timeout=600
+timeout=900
 sample=10
 
 oc wait --for=condition=Ready --timeout=${timeout}s dv/"${dv_name}" -n $namespace


### PR DESCRIPTION
In some cases, the current timeout of 600 seconds is insufficient for starting a virtual machine (VM). To address this issue, we propose increasing the timeout to 900 seconds, which should provide adequate time for the VM to start successfully.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
