### PR TITLE
fix: update legacy containerdisks url

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -12,15 +12,38 @@ if [ "$TARGET" == "centos6" ] && [ "$(uname -m)" == "s390x" ]; then
   exit 1
 fi
 
+containerdisks_url="docker://quay.io/containerdisks"
+legacy_common_templates_disk_url="docker://quay.io/kubevirt/common-templates"
+cnv_common_templates_url="docker://quay.io/openshift-cnv/ci-common-templates-images"
 image_url=""
 #set secret_ref only for rhel OSes
 secret_ref=""
-if [[ $TARGET =~ rhel.* ]]; then
-  image_url="docker://quay.io/openshift-cnv/ci-common-templates-images:${TARGET}"
-  secret_ref="secretRef: common-templates-container-disk-puller"
-else
-  image_url="docker://quay.io/kubevirt/common-templates:${TARGET}"
-fi
+
+case $TARGET in
+  centos-stream9)
+    image_url="${containerdisks_url}/centos-stream:9"
+    ;;
+  centos6)
+    image_url="${legacy_common_templates_disk_url}:centos6"
+    ;;
+  fedora)
+    image_url="${containerdisks_url}/fedora:latest"
+    ;;
+  opensuse)
+    image_url="${containerdisks_url}/opensuse-leap:15.6"
+    ;;
+  rhel*)
+    image_url="${cnv_common_templates_url}:${TARGET}"
+    secret_ref="secretRef: common-templates-container-disk-puller"
+    ;;
+  ubuntu)
+    image_url="${containerdisks_url}/ubuntu:24.04"
+    ;;
+  *)
+    echo "Target: $TARGET is not valid"
+    exit 1
+    ;;
+esac
 
 dv_name="${TARGET}-datavolume-original"
 


### PR DESCRIPTION
The only image that remains in legacy status is CentOS 6. The link https://quay.io/repository/containerdisks/centos?tab=tags currently contains only CentOS 7 and CentOS 8 images.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
