### PR TITLE
feat: target archictecture as a parameter

### DIFF
--- a/automation/test-linux.sh
+++ b/automation/test-linux.sh
@@ -7,11 +7,6 @@ namespace="kubevirt"
 ocenv="OC"
 k8senv="K8s"
 
-if [ "$TARGET" == "centos6" ] && [ "$(uname -m)" == "s390x" ]; then
-  echo "CentOS 6 does not support s390x."
-  exit 1
-fi
-
 containerdisks_url="docker://quay.io/containerdisks"
 legacy_common_templates_disk_url="docker://quay.io/kubevirt/common-templates"
 cnv_common_templates_url="docker://quay.io/openshift-cnv/ci-common-templates-images"

--- a/generate-templates.yaml
+++ b/generate-templates.yaml
@@ -3,6 +3,13 @@
   hosts: 127.0.0.1
   gather_facts: yes
   tasks:
+  - name: Ensure target_arch is defined
+    assert:
+      that: 
+        - target_arch is defined
+        - target_arch in ['x86_64', 's390x']
+      fail_msg: "Please define the target architecture as either 'x86_64' or 's390x'."
+
   - name: Prepare dist directory
     file:
       path: "{{ playbook_dir }}/dist/templates"
@@ -145,7 +152,7 @@
   - name: Load CentOS 6 versions
     set_fact:
       centos6_labels: "{{ lookup('osinfo', 'distro=centos') |map(attribute='short_id') |select('match', '^centos6\\.') |list |sort }}"
-    when: ansible_architecture != "s390x"
+    when: target_arch != "s390x"
 
   - name: Generate CentOS 6 templates
     template:
@@ -163,7 +170,7 @@
       oslabels: "{{ centos6_labels }}"
       osinfoname: "{{ oslabels[0] }}"
       cloudusername: centos
-    when: ansible_architecture != "s390x"
+    when: target_arch != "s390x"
 
   - name: Load Fedora versions
     set_fact:
@@ -171,8 +178,8 @@
 
   - name: Load Fedora containerdisk and image urls
     set_fact:
-      fedora_containerdisk_urls: "{{ fedora_containerdisk_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', ansible_architecture) |selectattr('format', 'eq', 'containerdisk') |map(attribute='url') |map('replace', 'docker://', '') |list }}"
-      fedora_image_urls: "{{ fedora_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', ansible_architecture) |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
+      fedora_containerdisk_urls: "{{ fedora_containerdisk_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', target_arch) |selectattr('format', 'eq', 'containerdisk') |map(attribute='url') |map('replace', 'docker://', '') |list }}"
+      fedora_image_urls: "{{ fedora_image_urls |default([]) + lookup('osinfo', item) |attr('image_list') |selectattr('architecture', 'eq', target_arch) |selectattr('format', 'in', ['raw', 'qcow2']) |map(attribute='url') |list }}"
     loop: "{{ fedora_labels }}"
 
   - name: Generate Fedora templates

--- a/makefile
+++ b/makefile
@@ -5,6 +5,9 @@ ALL_META_TEMPLATES=$(wildcard templates/*.yaml)
 ALL_PRESETS=$(wildcard presets/*.yaml)
 METASOURCES=$(ALL_META_TEMPLATES) $(ALL_PRESETS)
 
+# target architecture
+TARGET_ARCH?=x86_64
+
 # Make sure the version is defined
 export VERSION=$(shell ./version.sh)
 export REVISION=$(shell ./revision.sh)
@@ -41,7 +44,7 @@ validate-no-offensive-lang:
 generate: generate-templates.yaml $(METASOURCES)
 	# Just build the XML files, no need to export to tarball
 	make -C osinfo-db/ OSINFO_DB_EXPORT=echo
-	ansible-playbook generate-templates.yaml
+	ansible-playbook generate-templates.yaml -e "target_arch=$(TARGET_ARCH)"
 
 update-osinfo-db:
 	git submodule init

--- a/templates/fedora.tpl.yaml
+++ b/templates/fedora.tpl.yaml
@@ -95,9 +95,9 @@ objects:
           kubevirt.io/domain: ${NAME}
           kubevirt.io/size: {{ item.flavor }}
       spec:
-        architecture: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
+        architecture: "{{ 'amd64' if target_arch == 'x86_64' else target_arch }}"
         domain:
-{% if ansible_architecture != 's390x' %}
+{% if target_arch != 's390x' %}
           features:
             smm:
               enabled: true


### PR DESCRIPTION
The default value is x86_64, but it can be overridden. This change ensures compatibility with older versions.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
