### PR TITLE
fix: creation of /.ansible folder in builder dockerfile

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -6,10 +6,8 @@ RUN dnf install -y jq ansible python3-gobject python3-openshift python3-pip libo
 
 # Allow writes to /etc/passwd so a user for ansible can be added by CI commands
 RUN chmod a+w /etc/passwd
-
 # Create ansible tmp folder and set permissions
-RUN mkdir -p /.ansible/tmp && \
-    chmod -R 777 /.ansible
+RUN mkdir -m 777 -p /.ansible/tmp
 
 # Download latest stable oc client binary
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: creation of /.ansible folder in builder dockerfile

the automation for releases stopped working because of error with folder permission (https://github.com/kubevirt/common-templates/actions/runs/12034572916).
By changing the command to RUN mkdir -m 777 -p /.ansible/tmp the release automation started working (https://github.com/ksimon1/common-templates/actions/runs/12037461414/job/33560963925#step:4:1092).

**Release note**:
```
NONE
```
