### PR TITLE
chore: remove opokornyy from reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,4 +10,3 @@ reviewers:
   - fossedihelm
   - lyarwood
   - jcanocan
-  - opokornyy


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: remove opokornyy from reviewers

Ondra in no longer active as a reviewer in CT.
Thanks for all the work!

**Release note**:
```release-note
NONE
```
